### PR TITLE
Errors in codegenerator tests fixed

### DIFF
--- a/plugins/de.cognicrypt.codegenerator/src/test/java/crossing/e1/featuremodel/clafer/test/XMLParserTest.java
+++ b/plugins/de.cognicrypt.codegenerator/src/test/java/crossing/e1/featuremodel/clafer/test/XMLParserTest.java
@@ -11,6 +11,7 @@
 package crossing.e1.featuremodel.clafer.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -95,7 +96,7 @@ public class XMLParserTest {
 		testFile.read(generatedBytes);
 		testFile.close();
 
-		assertEquals(new String(validBytes), new String(generatedBytes));
+		assertTrue(uglifyXML(new String(validBytes)).trim().contentEquals(uglifyXML(new String(generatedBytes)).trim()));
 	}
 
 	@Test
@@ -122,6 +123,6 @@ public class XMLParserTest {
 	 * move all tags together and remove newlines
 	 */
 	public String uglifyXML(final String input) {
-		return input.replaceAll(">\\s*<", "><").replace("\n", "");
+		return input.replaceAll(">\\s*<", "><").replace("\n", "").replace("\r","").trim();
 	}
 }


### PR DESCRIPTION
Signed-off-by: shahrzad <shahrzadav@yahoo.com>

# Description

there was an inequality between two variables in one of codegenerator's test, that got fixed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Eclipse Version: Oxygen.3a Release (4.7.3a)
* Java Version: 8
* OS: Windows 10

# Checklist:

- [ ] New and existing unit tests pass locally with my changes

