### PR TITLE
Fixes a NPE in the Statistics View and 

### DIFF
--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
@@ -97,7 +97,6 @@ public class AnalysisKickOff {
 				final SootThread sootThread = new SootThread(AnalysisKickOff.this.curProj, AnalysisKickOff.resultsReporter);
 				sootThread.start();
 				while (sootThread.isAlive()) {
-					Activator.getDefault().logInfo("Tick.");
 					try {
 						Thread.sleep(500);
 					}

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
@@ -65,6 +65,7 @@ public class AnalysisKickOff {
 		resultsReporter.getMarkerGenerator().clearMarkers(ip);
 		try {
 			if (ip == null || (!ip.hasNature(JavaCore.NATURE_ID))) {
+				Activator.getDefault().logInfo("The project "+ ip.getName() +" does not have Java nature. No analysis necessary.");
 				return false;
 			}
 		}
@@ -72,16 +73,22 @@ public class AnalysisKickOff {
 			Activator.getDefault().logError(e);
 			return false;
 		}
-		this.curProj = JavaCore.create(ip);
+		IJavaProject javaProject = JavaCore.create(ip);
+		if(javaProject == null) {
+			Activator.getDefault().logInfo("JavaCore could not create IJavaProject for project "+ ip.getName() +" .");
+			return false;
+		}
+		this.curProj = javaProject;
 		return true;
 	}
 
 	/**
 	 * This method executes the actual analysis.
 	 *
-	 * @return <code>true</code>/<code>false</code> Soot runs successfully
 	 */
-	public boolean run() {
+	public void run() {
+		if(this.curProj == null)
+			return;
 		final Job analysis = new Job(Constants.ANALYSIS_LABEL) {
 
 			@SuppressWarnings("deprecation")
@@ -90,20 +97,25 @@ public class AnalysisKickOff {
 				final SootThread sootThread = new SootThread(AnalysisKickOff.this.curProj, AnalysisKickOff.resultsReporter);
 				sootThread.start();
 				while (sootThread.isAlive()) {
+					Activator.getDefault().logInfo("Tick.");
 					try {
 						Thread.sleep(500);
 					}
+					
 					catch (final InterruptedException e) {}
 
 					if (monitor.isCanceled()) {
 						sootThread.stop();
+						Activator.getDefault().logInfo("Static analysis job cancelled for "+ curProj.getElementName() +".");
 						return Status.CANCEL_STATUS;
 					}
 
 				}
 				if (sootThread.isSucc()) {
+					Activator.getDefault().logInfo("Static analysis job successfully terminated for "+ curProj.getElementName() +".");
 					return Status.OK_STATUS;
 				} else {
+					Activator.getDefault().logInfo("Static analysis failed for "+ curProj.getElementName() +".");
 					return Status.CANCEL_STATUS;
 				}
 
@@ -116,6 +128,5 @@ public class AnalysisKickOff {
 		};
 		analysis.setPriority(Job.LONG);
 		analysis.schedule();
-		return this.curProj != null && analysis.shouldRun();
 	}
 }

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
@@ -115,18 +115,12 @@ public class StartupHandler implements IStartup {
 				final boolean stat = ako.setUp(changedJavaElements.get(0));
 				if (stat) {
 					analysis_Queue.add(ako);
-				} else {
-					Activator.getDefault().logInfo("Analysis has been cancelled due to erroneous setup.");
 				}
 				while (analysis_Queue.size() > 0) {
 					if (!analysis_running) {
 						final AnalysisKickOff ak = analysis_Queue.remove();
 						analysis_running = true;
-						if (ak.run()) {
-							Activator.getDefault().logInfo("Analysis has finished.");
-						} else {
-							Activator.getDefault().logInfo("Analysis has aborted.");
-						}
+						ak.run();
 						analysis_running = false;
 					}
 				}

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/view/StatisticsView.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/view/StatisticsView.java
@@ -23,6 +23,9 @@ import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
+
+import com.google.common.base.Optional;
+
 import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.handlers.AnalysisKickOff;
 import de.cognicrypt.utils.Utils;
@@ -210,8 +213,10 @@ public class StatisticsView extends ViewPart {
 	public static void allowAnalysisRerun(boolean isAllowed) {
 		Display.getDefault().asyncExec(new Runnable() {
 			public void run() {
-				getView().allowAnalysisReRun(isAllowed);
-
+				Optional<StatisticsView> view = getView();
+				if(view.isPresent()) {
+					view.get().allowAnalysisReRun(isAllowed);
+				}
 			}
 		});
 	}
@@ -219,17 +224,20 @@ public class StatisticsView extends ViewPart {
 	public static void updateView(IProject project, String timeOfAnalysis, List<ResultsUnit> units) {
 		Display.getDefault().asyncExec(new Runnable() {
 			public void run() {
-				getView().updateData(project, timeOfAnalysis, units);
+				Optional<StatisticsView> view = getView();
+				if(view.isPresent()) {
+					view.get().updateData(project, timeOfAnalysis, units);
+				}
 			}
 		});
 	}
 
-	private static StatisticsView getView() {
+	private static Optional<StatisticsView> getView() {
 		IViewPart viewPart = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().findView("de.cognicrypt.staticanalyzer.view.StatisticsView");
 		if (viewPart != null) {
-			return (StatisticsView) viewPart;
+			return Optional.of((StatisticsView) viewPart);
 		}
-		return null;
+		return Optional.absent();
 	}
 
 }


### PR DESCRIPTION
Fixed a bug:
When the statistics view is not opened, the plugin crashes in a NPE.

Added some logging:
- Added project name to logging
- Added detailed description when the analysis was not performed or crashed
