### PR TITLE
Added java version check.

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
@@ -541,4 +541,7 @@ public class Constants {
 	public static final String cryslEditorID = "de.darmstadt.tu.crossing.CryptSL";
 	public static final String HEALTHY = "Secure";
 	public static final String UNHEALTHY = "Insecure";
+	
+	// define the max java version the plugin can run
+	public static final String CC_JAVA_VERSION = "1.8";
 }

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
@@ -18,6 +18,7 @@ import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
 import de.cognicrypt.staticanalyzer.results.ErrorMarkerGenerator;
 import de.cognicrypt.staticanalyzer.results.ResultsCCUIListener;
+import de.cognicrypt.staticanalyzer.utils.JavaVersion;
 import de.cognicrypt.utils.Utils;
 
 /**
@@ -89,6 +90,13 @@ public class AnalysisKickOff {
 	public void run() {
 		if(this.curProj == null)
 			return;
+		String javaVersion = System.getProperty("java.version");
+		JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
+		JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
+		if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
+			Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
+			return;
+		}
 		final Job analysis = new Job(Constants.ANALYSIS_LABEL) {
 
 			@SuppressWarnings("deprecation")

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IStartup;
 import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
+import de.cognicrypt.staticanalyzer.utils.JavaVersion;
 
 /**
  * At startup, this handler registers a listener that will be informed after a build, whenever resources were changed.
@@ -50,8 +51,14 @@ public class StartupHandler implements IStartup {
 		 */
 		@Override
 		public void resourceChanged(final IResourceChangeEvent event) {
+			String javaVersion = System.getProperty("java.version");
+			JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
+			JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
 			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 			if (store.getBoolean(Constants.AUTOMATED_ANALYSIS) == false) {
+				return;
+			} else if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
+				Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
 				return;
 			}else {
 			final List<IJavaElement> changedJavaElements = new ArrayList<>();

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
@@ -1,0 +1,52 @@
+package de.cognicrypt.staticanalyzer.utils;
+
+public class JavaVersion implements Comparable<JavaVersion> {
+	/**
+	 * This class can be used to compare two different java versions.
+	 * Ex: Let a and b are two JavaVersion objects,
+	 * 	   a.compareTo(b)
+	 * 			returns -1 (when a<b)
+	 * 			returns 0  (when a=b)
+	 * 			returns 1  (when a>b)*/
+    private String version;
+
+    public final String get() {
+        return this.version;
+    }
+
+    public JavaVersion(String version) {
+        if(version == null)
+            throw new IllegalArgumentException("Version can not be null");
+        this.version = version;
+    }
+
+    @Override public int compareTo(JavaVersion that) {
+        if(that == null)
+            return 1;
+        String[] thisParts = this.get().split("\\.");
+        String[] thatParts = that.get().split("\\.");
+        int length = Math.min(thisParts.length, thatParts.length);
+        for(int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ?
+                Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ?
+                Integer.parseInt(thatParts[i]) : 0;
+            if(thisPart < thatPart)
+                return -1;
+            if(thisPart > thatPart)
+                return 1;
+        }
+        return 0;
+    }
+
+    @Override public boolean equals(Object that) {
+        if(this == that)
+            return true;
+        if(that == null)
+            return false;
+        if(this.getClass() != that.getClass())
+            return false;
+        return this.compareTo((JavaVersion) that) == 0;
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Kummita Sriteja <sritejak@campus.uni-paderborn.de>

# Description

Before running the analysis, java version of the IDE is checked and analysis is canceled if the version is greater than the required version for the plugin.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by running the plugin in inner eclipse and checking the error logs for the message when the java version of the IDE is greater than the required version.

**Test Configuration**:
* Eclipse Version: 2018-12
* Java Version: 1.8.0_144
* OS: MacOS

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
