### PR TITLE
Added java version check.

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
@@ -541,4 +541,7 @@ public class Constants {
 	public static final String cryslEditorID = "de.darmstadt.tu.crossing.CryptSL";
 	public static final String HEALTHY = "Secure";
 	public static final String UNHEALTHY = "Insecure";
+	
+	// define the max java version before which plugin works.
+	public static final String CC_JAVA_VERSION = "1.8";
 }

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/JavaVersion.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/JavaVersion.java
@@ -1,4 +1,4 @@
-package de.cognicrypt.staticanalyzer.utils;
+package de.cognicrypt.utils;
 
 public class JavaVersion implements Comparable<JavaVersion> {
 	/**

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -47,6 +47,7 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.osgi.framework.Bundle;
 import com.google.common.base.CharMatcher;
 import de.cognicrypt.core.Activator;
+import de.cognicrypt.core.Constants;
 
 public class Utils {
 
@@ -338,5 +339,15 @@ public class Utils {
 		headerGroup.setLayout(new GridLayout(1, true));
 		return headerGroup;
 	}
-
+	
+	public static boolean checkJavaVersion() {
+		String javaVersion = System.getProperty("java.version", null);
+		if (javaVersion == null)
+			return true;
+		JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
+		JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
+		if (systemJavaVersion.compareTo(requiredJavaVersion) == 1)
+			return true;
+		return false;
+	}
 }

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
@@ -18,7 +18,7 @@ import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
 import de.cognicrypt.staticanalyzer.results.ErrorMarkerGenerator;
 import de.cognicrypt.staticanalyzer.results.ResultsCCUIListener;
-import de.cognicrypt.staticanalyzer.utils.JavaVersion;
+import de.cognicrypt.utils.JavaVersion;
 import de.cognicrypt.utils.Utils;
 
 /**
@@ -90,11 +90,8 @@ public class AnalysisKickOff {
 	public void run() {
 		if(this.curProj == null)
 			return;
-		String javaVersion = System.getProperty("java.version");
-		JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
-		JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
-		if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
-			Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
+		if (Utils.checkJavaVersion()) {
+			Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + System.getProperty("java.version", "<JavaVersionNotFound>") + ", which is greater than 1.8.");
 			return;
 		}
 		final Job analysis = new Job(Constants.ANALYSIS_LABEL) {

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/AnalysisKickOff.java
@@ -18,6 +18,7 @@ import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
 import de.cognicrypt.staticanalyzer.results.ErrorMarkerGenerator;
 import de.cognicrypt.staticanalyzer.results.ResultsCCUIListener;
+import de.cognicrypt.staticanalyzer.utils.JavaVersion;
 import de.cognicrypt.utils.Utils;
 
 /**
@@ -89,6 +90,13 @@ public class AnalysisKickOff {
 	public void run() {
 		if(this.curProj == null)
 			return;
+		String javaVersion = System.getProperty("java.version");
+		JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
+		JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
+		if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
+			Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
+			return;
+		}
 		final Job analysis = new Job(Constants.ANALYSIS_LABEL) {
 
 			@SuppressWarnings("deprecation")

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IStartup;
 import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
+import de.cognicrypt.staticanalyzer.utils.JavaVersion;
 
 /**
  * At startup, this handler registers a listener that will be informed after a build, whenever resources were changed.
@@ -50,8 +51,14 @@ public class StartupHandler implements IStartup {
 		 */
 		@Override
 		public void resourceChanged(final IResourceChangeEvent event) {
+			String javaVersion = System.getProperty("java.version");
+			JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
+			JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
 			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 			if (store.getBoolean(Constants.AUTOMATED_ANALYSIS) == false) {
+				return;
+			} else if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
+				Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
 				return;
 			}else {
 			final List<IJavaElement> changedJavaElements = new ArrayList<>();

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/StartupHandler.java
@@ -23,7 +23,8 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IStartup;
 import de.cognicrypt.core.Constants;
 import de.cognicrypt.staticanalyzer.Activator;
-import de.cognicrypt.staticanalyzer.utils.JavaVersion;
+import de.cognicrypt.utils.JavaVersion;
+import de.cognicrypt.utils.Utils;
 
 /**
  * At startup, this handler registers a listener that will be informed after a build, whenever resources were changed.
@@ -51,14 +52,11 @@ public class StartupHandler implements IStartup {
 		 */
 		@Override
 		public void resourceChanged(final IResourceChangeEvent event) {
-			String javaVersion = System.getProperty("java.version");
-			JavaVersion systemJavaVersion = new JavaVersion(javaVersion);
-			JavaVersion requiredJavaVersion = new JavaVersion(Constants.CC_JAVA_VERSION);
 			IPreferenceStore store = Activator.getDefault().getPreferenceStore();
 			if (store.getBoolean(Constants.AUTOMATED_ANALYSIS) == false) {
 				return;
-			} else if (javaVersion != "" && systemJavaVersion.compareTo(requiredJavaVersion) == 1) {
-				Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + javaVersion + ", which is greater than 1.8.");
+			} else if (Utils.checkJavaVersion()) {
+				Activator.getDefault().logInfo("Analysis cancelled as the IDEs' java version is " + System.getProperty("java.version", "<JavaVersionNotFound>") + ", which is greater than 1.8.");
 				return;
 			}else {
 			final List<IJavaElement> changedJavaElements = new ArrayList<>();

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
@@ -1,0 +1,46 @@
+package de.cognicrypt.staticanalyzer.utils;
+
+public class JavaVersion implements Comparable<JavaVersion> {
+
+    private String version;
+
+    public final String get() {
+        return this.version;
+    }
+
+    public JavaVersion(String version) {
+        if(version == null)
+            throw new IllegalArgumentException("Version can not be null");
+        this.version = version;
+    }
+
+    @Override public int compareTo(JavaVersion that) {
+        if(that == null)
+            return 1;
+        String[] thisParts = this.get().split("\\.");
+        String[] thatParts = that.get().split("\\.");
+        int length = Math.min(thisParts.length, thatParts.length);
+        for(int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ?
+                Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ?
+                Integer.parseInt(thatParts[i]) : 0;
+            if(thisPart < thatPart)
+                return -1;
+            if(thisPart > thatPart)
+                return 1;
+        }
+        return 0;
+    }
+
+    @Override public boolean equals(Object that) {
+        if(this == that)
+            return true;
+        if(that == null)
+            return false;
+        if(this.getClass() != that.getClass())
+            return false;
+        return this.compareTo((JavaVersion) that) == 0;
+    }
+
+}

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utils/JavaVersion.java
@@ -1,6 +1,13 @@
 package de.cognicrypt.staticanalyzer.utils;
 
 public class JavaVersion implements Comparable<JavaVersion> {
+	/**
+	 * This class is used to compare different java version strings.
+	 * Ex: If a and b are JavaVersion objects, then
+	 * 			returns -1 (a<b)
+	 * 			returns 0  (a=b)
+	 * 			returns 1  (a>b)
+	 * */
 
     private String version;
 


### PR DESCRIPTION
Signed-off-by: Kummita Sriteja <sriteja.ku@gmail.com>

# Description

Before analysis is run, java version of the IDE is checked against the required java version of the plugin and analysis is canceled if the IDE java version is higher by displaying an error message.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] By running the plugin in inner eclipse with IDE version greater than required java version (1.8)

**Test Configuration**:
* Eclipse Version: 2018 -12
* Java Version: 1.8.0_144
* OS: MacOS

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
