### PR TITLE
Error marker changes to info marker on suppressing the error.

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
@@ -500,6 +500,7 @@ public class Constants {
 
 	// QuickFixs
 	public static final String SUPPRESSWARNING_FIX = "Suppress Warning: ";
+	public static final String UNSUPPRESSWARNING_FIX = "UnSuppress Warning: ";
 
 	// Marker types
 	public static final String CC_MARKER_TYPE = "de.cognicrypt.staticanalyzer.ccMarker";

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/QuickFixer.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/QuickFixer.java
@@ -26,12 +26,18 @@ public class QuickFixer implements IMarkerResolutionGenerator {
 		quickFixes = new ArrayList<>();
 		String message = "";
 		String errorType = "";
-
+		int severity;
 		try {
+			severity = (int) mk.getAttribute(IMarker.SEVERITY);
 			errorType = (String) mk.getAttribute("errorType");
 			message = (String) mk.getAttribute(IMarker.MESSAGE);
-			quickFixes.add(new SuppressWarningFix(Constants.SUPPRESSWARNING_FIX + message));
-
+			if(severity == 2) {
+				quickFixes.add(new SuppressWarningFix(Constants.SUPPRESSWARNING_FIX + message));
+			}
+			else if(severity == 0) {
+				quickFixes.add(new UnSuppressWarningFix(Constants.UNSUPPRESSWARNING_FIX + message));
+			}
+			
 			if (errorType.equals(Constants.REQUIRED_PREDICATE_MARKER_TYPE)) {
 				String predicate = (String) mk.getAttribute("predicate");
 

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/SuppressWarningFix.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/SuppressWarningFix.java
@@ -12,8 +12,7 @@ import de.cognicrypt.staticanalyzer.Activator;
 import de.cognicrypt.utils.XMLParser;
 
 /**
- * This class writes the suppress warning information in a XML file and deletes the marker on the UI
- *
+ * This class writes the suppress warning information in a XML file and updates the error marker to info marker on the UI
  * @author André Sonntag
  */
 public class SuppressWarningFix implements IMarkerResolution {
@@ -67,7 +66,8 @@ public class SuppressWarningFix implements IMarkerResolution {
 
 			createSuppressWarningEntry(marker);
 			this.xmlParser.writeXML();
-			marker.delete();
+			/* changes error marker to info marker */
+			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
 			marker.getResource().getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
 		}
 		catch (final IOException e) {

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/UnSuppressWarningFix.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/markerresolution/UnSuppressWarningFix.java
@@ -1,0 +1,56 @@
+package de.cognicrypt.staticanalyzer.markerresolution;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IMarkerResolution;
+
+import de.cognicrypt.core.Constants;
+import de.cognicrypt.staticanalyzer.Activator;
+import de.cognicrypt.utils.XMLParser;
+
+/**
+ * This class removes the suppressed warning data from SuppresssedWarning.xml and changes info marker to error marker
+ *
+ * @author Seena Mathew
+ */
+public class UnSuppressWarningFix implements IMarkerResolution{
+
+	private final String label;
+	private XMLParser xmlParser;
+	
+	public UnSuppressWarningFix(final String label) {
+		super();
+		this.label = label;
+		}
+	
+	@Override
+	public String getLabel() {
+		return this.label;
+	}
+	
+	@Override
+	public void run(final IMarker marker) {
+		final File warningsFile = new File(marker.getResource().getProject().getLocation().toOSString() + Constants.outerFileSeparator + Constants.SUPPRESSWARNING_FILE);
+		this.xmlParser = new XMLParser(warningsFile);
+		try {
+			if (warningsFile.exists()) {
+				this.xmlParser.useDocFromFile();
+			} else {
+				this.xmlParser.createNewDoc();
+				this.xmlParser.createRootElement(Constants.SUPPRESSWARNINGS_ELEMENT);
+			}
+			
+			this.xmlParser.removeNodeByAttrValue(Constants.SUPPRESSWARNING_ELEMENT, Constants.ID_ATTR, marker.getAttribute(IMarker.SOURCE_ID) + "");
+			this.xmlParser.writeXML();
+			marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+			marker.getResource().getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
+		}
+		catch (final CoreException e) {
+			Activator.getDefault().logError(e);
+		}
+	
+	}
+}

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/results/ErrorMarkerGenerator.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/results/ErrorMarkerGenerator.java
@@ -50,7 +50,7 @@ public class ErrorMarkerGenerator {
 	 *         successfully
 	 */
 	public boolean addMarker(final String markerType, final int id, final IResource sourceFile, final int line,
-			final String message, final Severities sev, final HashMap<String, String> additionalErrorInfos) {
+			final String message, final Severities sev, final HashMap<String, String> additionalErrorInfos, boolean isSuppressed) {
 
 		if (!sourceFile.exists() || !sourceFile.isAccessible()) {
 			Activator.getDefault().logError(Constants.NO_RES_FOUND);
@@ -64,7 +64,12 @@ public class ErrorMarkerGenerator {
 			marker.setAttribute(IMarker.LINE_NUMBER, line);
 			marker.setAttribute(IMarker.MESSAGE, message);
 			marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			if(isSuppressed) {
+				marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+			}
+			else {
 			marker.setAttribute(IMarker.SEVERITY, (sev == Severities.Error) ? IMarker.SEVERITY_ERROR : ((sev == Severities.Warning) ? IMarker.SEVERITY_WARNING : IMarker.SEVERITY_INFO));
+			}
 			marker.setAttribute(IMarker.SOURCE_ID, id);
 
 			if(markerType.equals(Constants.REQUIRED_PREDICATE_MARKER_TYPE)) {

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/results/ResultsCCUIListener.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/results/ResultsCCUIListener.java
@@ -194,13 +194,13 @@ public class ResultsCCUIListener extends CrySLAnalysisListener {
 		final File warningsFile = new File(this.warningFilePath);
 
 		if (!warningsFile.exists()) {
-			this.markerGenerator.addMarker(markerType, stmtId, sourceFile, lineNumber, errorMessage, sev, errorInfoMap);
+			this.markerGenerator.addMarker(markerType, stmtId, sourceFile, lineNumber, errorMessage, sev, errorInfoMap, false);
 		} else {
 			this.xmlParser = new XMLParser(warningsFile);
 			this.xmlParser.useDocFromFile();
 			String idAsString = String.valueOf(stmtId);
 			if (!this.xmlParser.getAttrValuesByAttrName(Constants.SUPPRESSWARNING_ELEMENT, Constants.ID_ATTR).contains(idAsString)) {
-				this.markerGenerator.addMarker(markerType, stmtId, sourceFile, lineNumber, errorMessage, sev, errorInfoMap);
+				this.markerGenerator.addMarker(markerType, stmtId, sourceFile, lineNumber, errorMessage, sev, errorInfoMap, false);
 			} else {
 
 				// update existing line number
@@ -208,7 +208,8 @@ public class ResultsCCUIListener extends CrySLAnalysisListener {
 				final Node lineNumberNode = this.xmlParser.getChildNodeByTagName(suppressWarningNode, Constants.LINENUMBER_ELEMENT);
 				this.xmlParser.updateNodeValue(lineNumberNode, lineNumber + "");
 				this.xmlParser.writeXML();
-
+				// last parameter(true) implies that the error was suppressed and info marker has to be shown.
+				this.markerGenerator.addMarker(markerType, stmtId, sourceFile, lineNumber, errorMessage, sev, errorInfoMap, true);
 				try {
 					this.currentProject.refreshLocal(IResource.DEPTH_INFINITE, null);
 				} catch (final CoreException e) {
@@ -245,7 +246,7 @@ public class ResultsCCUIListener extends CrySLAnalysisListener {
 			}
 			final Value varName = var.getValue();
 			this.markerGenerator.addMarker(Constants.CC_MARKER_TYPE, -1, unitToResource(stmt), unit.getJavaSourceStartLineNumber(),
-					"Object " + (varName.toString().startsWith("$r") ? " of Type " + var.getValue().getType().toQuotedString() : varName) + " is secure.", Severities.Info, new HashMap<>());		}
+					"Object " + (varName.toString().startsWith("$r") ? " of Type " + var.getValue().getType().toQuotedString() : varName) + " is secure.", Severities.Info, new HashMap<>(), false);		}
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: seena-mathew <seenamathew078@gmail.com>

# Description

The errors generated after CryptoAnalysis can be suppressed. Suppressing of these error changes error markers to info markers. It can be reverted back to error marker using the UnSuppress quick fix. This removes the corresponding error entry from SuppressedWarning.xml

Fixes #302.

