### PR TITLE
remove default collapsable advance option

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/properties/CogniCryptPreferencePage.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/properties/CogniCryptPreferencePage.java
@@ -39,7 +39,6 @@ public class CogniCryptPreferencePage extends PreferencePage implements IWorkben
 		advancedOptions.setLayout(new RowLayout(SWT.VERTICAL));
 		notifyAdvancedPreferenceListeners(advancedOptions);
 
-		collap.setExpanded(true);
 		return container;
 	}
 


### PR DESCRIPTION
Signed-off-by: Shahrzad <shahrzad.asghari73@gmail.com>

# Description

Changed default status of advance option in preference page to false (shrink).

Fixes #268

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested in runtime

**Test Configuration**:
* Eclipse Version: 2018-12 (4.10.0)
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

