### PR TITLE
Enabled show secureObj option in preference page

### DIFF
--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
@@ -76,20 +76,10 @@ public class StaticAnalyzerPreferences extends PreferenceListener {
 
 		automatedAnalysisCheckBox = new Button(staticAnalysisGroup, SWT.CHECK);
 		automatedAnalysisCheckBox.setText("Enable automated analysis when saving");
-		automatedAnalysisCheckBox.addSelectionListener(new SelectionAdapter() {
-	        @Override
-	        public void widgetSelected(SelectionEvent event) {
-	 
-	        	secureObjectsCheckBox.setEnabled(automatedAnalysisCheckBox.getSelection());
-	    	    //in case we do not want to see warnings also from context menu
-	    	    /*if (!automatedAnalysisCheckBox.getSelection()) {
-	    	    	store.setValue(ICogniCryptConstants.PRE_CHECKBOX4, store.getBoolean(ICogniCryptConstants.PRE_CHECKBOX3));
-	    	    	checkBox4.setSelection(false);
-	    	    }*/ 
-	        }
-	    });
+		
 		secureObjectsCheckBox = new Button(staticAnalysisGroup, SWT.CHECK);
 		secureObjectsCheckBox.setText("Show secure objects");
+		
 		analyseDependenciesCheckBox = new Button(staticAnalysisGroup,SWT.CHECK); 
 		analyseDependenciesCheckBox.setText("Include dependencies to projects analysis");
 		analyseDependenciesCheckBox.setSelection(preferences.getBoolean(Constants.ANALYSE_DEPENDENCIES));


### PR DESCRIPTION
Signed-off-by: Shahrzad <shahrzad.asghari73@gmail.com>

# Description

Show Secure object option in preference page was enabled only when automatic analysis was selected. Now it is enabled independently from automatic analysis.

Fixes #326

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in runtime

**Test Configuration**:
* Eclipse Version:  2018-12 (4.10.0)
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

