### PR TITLE
Resolved error on empty editor while analyzing from context menu

### DIFF
--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/RunAnalysisHandler.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/handlers/RunAnalysisHandler.java
@@ -29,7 +29,8 @@ public class RunAnalysisHandler extends AbstractHandler {
 		IEditorPart openEditor = Utils.getCurrentlyOpenEditor();
 
 //		check if there are unsaved changes
-		if (openEditor.isDirty()) {
+		
+		if (openEditor != null && openEditor.isDirty()) {
 			int answr = saveFile(Utils.getCurrentlyOpenFile());
 //			save file and analyze
 			if (answr == JOptionPane.YES_OPTION) {


### PR DESCRIPTION
Signed-off-by: Shahrzad <shahrzad.asghari73@gmail.com>

# Description

When there were no file open in editor, it caused an error when the analysis was triggered from the context menu. But it is now resolved by adding a not null condition.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in runtime

**Test Configuration**:
* Eclipse Version:  2018-12 (4.10.0)
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

