### PR TITLE
Changed the dir of the JCA rules that are needed for CrySL code gen

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
@@ -22,6 +22,11 @@ public class Constants {
 	public enum CodeGenerators {
 		XSL, CrySL
 	}
+	
+	public enum Rules {
+		JavaCryptographicArchitecture, BouncyCastle, Tink
+	}
+	
 	public enum Severities {
 		Error, Warning, Info, Ignored;
 

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -410,7 +410,7 @@ public class Utils {
 		String srcFormat = RuleFormat.SOURCE.toString();
 		File ruleRes = new File(System.getProperty("user.dir") + slash + defaultRuleset + slash + latestVersion + slash + defaultRuleset + slash + cryptslRule + srcFormat);
 		if (ruleRes == null || !ruleRes.exists() || !ruleRes.canRead()) {
-			ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + "/" + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
+			ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + slash + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
 		}
 		return (new CrySLModelReader()).readRule(ruleRes);
 	}

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -403,7 +403,12 @@ public class Utils {
 	 * @throws MalformedURLException
 	 */
 	public static CryptSLRule getCryptSLRule(String cryptslRule) throws MalformedURLException {
-		File ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + "/" + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
+		String defaultRuleset = Constants.Rules.JavaCryptographicArchitecture.toString();
+		String[] versionRules = getRuleVersions(defaultRuleset);
+		String latestVersion = versionRules[versionRules.length - 1];
+		String slash = File.separator;
+		String srcFormat = RuleFormat.SOURCE.toString();
+		File ruleRes = new File(System.getProperty("user.dir") + slash + defaultRuleset + slash + latestVersion + slash + defaultRuleset + slash + cryptslRule + srcFormat);
 		if (ruleRes == null || !ruleRes.exists() || !ruleRes.canRead()) {
 			ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + "/" + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
 		}

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -403,14 +403,11 @@ public class Utils {
 	 * @throws MalformedURLException
 	 */
 	public static CryptSLRule getCryptSLRule(String cryptslRule) throws MalformedURLException {
-		String defaultRuleset = Constants.Rules.JavaCryptographicArchitecture.toString();
-		String[] versionRules = getRuleVersions(defaultRuleset);
-		String latestVersion = versionRules[versionRules.length - 1];
-		String slash = File.separator;
-		String srcFormat = RuleFormat.SOURCE.toString();
-		File ruleRes = new File(System.getProperty("user.dir") + slash + defaultRuleset + slash + latestVersion + slash + defaultRuleset + slash + cryptslRule + srcFormat);
+		File ruleRes = new File(Constants.ECLIPSE_RULES_DIR + Constants.innerFileSeparator + Constants.Rules.JavaCryptographicArchitecture.toString() + Constants.innerFileSeparator + 
+								getRuleVersions(Constants.Rules.JavaCryptographicArchitecture.toString())[getRuleVersions(Constants.Rules.JavaCryptographicArchitecture.toString()).length - 1] + 
+								Constants.innerFileSeparator + Constants.Rules.JavaCryptographicArchitecture.toString() + Constants.innerFileSeparator + cryptslRule + RuleFormat.SOURCE.toString());
 		if (ruleRes == null || !ruleRes.exists() || !ruleRes.canRead()) {
-			ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + slash + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
+			ruleRes = Utils.getResourceFromWithin(Constants.RELATIVE_CUSTOM_RULES_DIR + Constants.innerFileSeparator + cryptslRule + RuleFormat.SOURCE.toString(), de.cognicrypt.core.Activator.PLUGIN_ID);
 		}
 		return (new CrySLModelReader()).readRule(ruleRes);
 	}


### PR DESCRIPTION
Signed-off-by: Enri Ozuni <enriozuni@hotmail.com>

# Description

This PR changes the location of the directory where the JCA rules are, that are needed for the CrySL based code generation. The previous directory was in ```core > resources > CrySLRules > Custom```, and now it is changed into the Eclipse installation directory.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] This was tested in inner Eclipse and seen if CC GEN plugin works properly.

**Test Configuration**:
* Eclipse Version: 2019-09 R (4.13.0)
* Java Version: 8
* OS: Win10

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

