### PR TITLE
advance pref page expanded by default, fixed rules not being downloaded

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/properties/CogniCryptPreferencePage.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/properties/CogniCryptPreferencePage.java
@@ -49,6 +49,7 @@ public class CogniCryptPreferencePage extends PreferencePage implements IWorkben
 		advancedOptions.setLayout(new RowLayout(SWT.VERTICAL));
 		notifyAdvancedPreferenceListeners(advancedOptions);
 
+		collap.setExpanded(true);
 		return container;
 	}
 

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -358,7 +358,10 @@ public class Utils {
  		List<String> versions = new ArrayList<String>();
  		File path = new File(System.getProperty("user.dir") + File.separator + ruleSet);
  		File[] innerDirs = path.listFiles();
- 		for (File f: innerDirs) {
+ 		if (innerDirs == null) {
+ 			return null;
+ 		}
+ 			for (File f: innerDirs) {
  			if (f.isDirectory()) {
  				String[] versionNumber = f.getPath().split(Matcher.quoteReplacement(System.getProperty("file.separator")));
  				versions.add(versionNumber[versionNumber.length - 1]);

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
@@ -186,12 +186,16 @@ public class StaticAnalyzerPreferences extends PreferenceListener {
  		for (Iterator<Ruleset> itr = listOfRulesets.iterator(); itr.hasNext();) {
  			Ruleset ruleset = (Ruleset) itr.next();
  			ruleset.setVersions(new CCombo(table.getTable(), SWT.NONE));
+ 			String[] items = Utils.getRuleVersions(ruleset.getFolderName());
+ 			if (items != null) {
+				ruleset.getVersions().setItems(items);
  			ruleset.getVersions()
  					.setItems(Utils.getRuleVersions(ruleset.getFolderName()));
  			ruleset.setSelectedVersion((ruleset.getSelectedVersion().length() > 0) ? ruleset.getSelectedVersion()
  					: ruleset.getVersions().getItem(ruleset.getVersions().getItemCount() - 1));
  			ruleset.getVersions().select(ruleset.getVersions().indexOf(ruleset.getSelectedVersion()));
- 			createRulesTableRow(ruleset);
+			}
+			createRulesTableRow(ruleset);
  			ruleset.getVersions().addSelectionListener(new SelectionAdapter() {
  				@Override
  				public void widgetSelected(SelectionEvent e) {


### PR DESCRIPTION
# Description
Advanced option in CogniCrypt preference page is now expanded by default due to resizing issue. There was an issue with rules not being automatically downloaded that got temporarily fixed.

Fixes #348 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It has been tested in runtime.

**Test Configuration**:
* Eclipse Version: 2019-09 R (4.13.0)
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

