### PR TITLE
Synchronizing the jar files to reflect what is obtained from the mave…

### DIFF
--- a/plugins/de.cognicrypt.core/build.properties
+++ b/plugins/de.cognicrypt.core/build.properties
@@ -20,7 +20,7 @@ bin.includes = META-INF/,\
                lib/asm-commons.jar,\
                lib/asm-tree.jar,\
                lib/asm-util.jar,\
-               lib/asm.jar,\
+               lib/asm-debug-all.jar,\
                lib/axml.jar,\
                lib/boomerangPDS.jar,\
                lib/checker-compat-qual.jar,\
@@ -62,7 +62,7 @@ bin.includes = META-INF/,\
                lib/polyglot.jar,\
                lib/slf4j-api.jar,\
                lib/slf4j-simple.jar,\
-               lib/soot-j9.jar,\
+               lib/soot.jar,\
                lib/synchronizedPDS.jar,\
                lib/testCore.jar,\
                lib/WPDS.jar,\


### PR DESCRIPTION
…n (for soot and asm)

# Description

Discovered that the jar files in the build path were not matching the expected jar files in the lib folder. Renamed them for the two jars that were causing the issue. We need to consider a more robust solution to ensure that such synchronizing effort is not required every time the remote artifact does not change the naming convention. 



