### PR TITLE
BouncyCastle-JCA ruleset option in preference page

### DIFF
--- a/plugins/de.cognicrypt.core/configuration.ini
+++ b/plugins/de.cognicrypt.core/configuration.ini
@@ -3,3 +3,4 @@ NEXUS_SOOT_RELEASE=https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-
 JCA_NEXUS=https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/de/darmstadt/tu/crossing/JavaCryptographicArchitecture
 BC_NEXUS=https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/de/fraunhofer/iem/BouncyCastle
 TINK_NEXUS=https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/de/darmstadt/tu/crossing/Tink
+BCJCA_NEXUS=https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/de/paderborn/uni/BouncyCastle-JCA

--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/core/Constants.java
@@ -589,6 +589,7 @@ public class Constants {
  	public static final Double MIN_JCA_RULE_VERSION = 1.4;
  	public static final Double MIN_BC_RULE_VERSION = 0.7;
  	public static final Double MIN_TINK_RULE_VERSION = 0.3;
+ 	public static final Double MIN_BCJCA_RULE_VERSION = 0.2;
 
  	//Configuration.ini keys
  	public static final String INI_URL_HEADER = "URLS";
@@ -596,6 +597,7 @@ public class Constants {
  	public static final String INI_JCA_NEXUS = "JCA_NEXUS";
  	public static final String INI_BC_NEXUS = "BC_NEXUS";
  	public static final String INI_TINK_NEXUS = "TINK_NEXUS";
+ 	public static final String INI_BCJCA_NEXUS = "BCJCA_NEXUS";
  	
  	public final static String CONFIG_FILE_PATH = "configuration.ini";
 

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/ArtifactUtils.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/ArtifactUtils.java
@@ -40,6 +40,7 @@ public class ArtifactUtils {
 		defaultRulesetUrls.put(ini.get(Constants.INI_JCA_NEXUS), Constants.MIN_JCA_RULE_VERSION);
 		defaultRulesetUrls.put(ini.get(Constants.INI_BC_NEXUS), Constants.MIN_BC_RULE_VERSION);
 		defaultRulesetUrls.put(ini.get(Constants.INI_TINK_NEXUS), Constants.MIN_TINK_RULE_VERSION);
+		defaultRulesetUrls.put(ini.get(Constants.INI_BCJCA_NEXUS), Constants.MIN_BCJCA_RULE_VERSION);
 
 		Iterator<Entry<String, Double>> it = defaultRulesetUrls.entrySet().iterator();
 		while (it.hasNext()) {

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/DefaultRulePreferences.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/DefaultRulePreferences.java
@@ -27,6 +27,7 @@ public class DefaultRulePreferences {
 			 			add(new Ruleset(ini.get(Constants.INI_JCA_NEXUS), true));
 			 			add(new Ruleset(ini.get(Constants.INI_BC_NEXUS)));
 			 			add(new Ruleset(ini.get(Constants.INI_TINK_NEXUS)));
+			 			add(new Ruleset(ini.get(Constants.INI_BCJCA_NEXUS)));
 			 		}
 			 	};
 			 	for (Iterator<Ruleset> itr = listOfRulesets.iterator(); itr.hasNext();) {


### PR DESCRIPTION
This PR contains the ruleset option for the BouncyCastle-JCA ruleset. It also makes sure that all the versions of the BouncyCastle-JCA ruleset are downloaded into the Eclipse folder, similar to the other rulesets.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested when running inner Eclipse and checking if the rules are downloaded in the Eclipse folder.
- [X] Tested by checking if the BC-JCA ruleset option is added in the preference page.

**Test Configuration**:
* Eclipse Version: 2019-06
* Java Version: 1.8
* OS: Wiindows 10

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

