### PR TITLE
Not visible error marker - fix

### DIFF
--- a/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
+++ b/plugins/de.cognicrypt.core/src/de/cognicrypt/utils/Utils.java
@@ -89,7 +89,7 @@ public class Utils {
 						if (name.startsWith(".")) {
 							name = name.substring(1);
 						}
-						if (name.startsWith(className)) {
+						if (name.equals(className)) {
 							return cu.getCorrespondingResource();
 						}
 					}


### PR DESCRIPTION
Signed-off-by: AndreSonntag <Andre-Sonntag@gmx.de>

# Description
This pull request contains the fix for the correct displaying of the error markers.

Fixes # (issue)
In certain cases Eclipse didn't display all errormarkers.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:
-  I have performed a self-review of my own code
- My changes generate no new warnings

