### PR TITLE
Use https for update site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CogniCrypt is an Eclipse plugin that supports Java developers in using cryptogra
 
 ## Installation
 
-To set up CogniCrypt in your own Eclipse, please install it from the [**Update Site**](http://download.eclipse.org/cognicrypt/stable). If it is your first time using CogniCrypt, we recommend you to browse [Eclipse website](https://www.eclipse.org/cognicrypt/) and check out the [**tutorial**](https://github.com/CROSSINGTUD/CogniCrypt/wiki/Tutorial) in this project's wiki. Nightly builds of CogniCrypt are also [available](http://download.eclipse.org/cognicrypt/snapshot).
+To set up CogniCrypt in your own Eclipse, please install it from the [**Update Site**](https://download.eclipse.org/cognicrypt/stable). If it is your first time using CogniCrypt, we recommend you to browse [Eclipse website](https://www.eclipse.org/cognicrypt/) and check out the [**tutorial**](https://github.com/CROSSINGTUD/CogniCrypt/wiki/Tutorial) in this project's wiki. Nightly builds of CogniCrypt are also [available](https://download.eclipse.org/cognicrypt/snapshot).
 
 
 ## Contribution


### PR DESCRIPTION
Eclipse supports this and since the plugin is not signed, it is a little safer to use this way.
This is also wrong on the website: https://www.eclipse.org/cognicrypt/downloads/

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Install in eclipse with new URL 

**Test Configuration**:
* Eclipse Version: Photon
* Java Version: 1.8
* OS: Linux

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

