### PR TITLE
Removing the dispose call which blocks the code generator wizard infi…

### DIFF
--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
@@ -296,7 +296,6 @@ public class AltConfigWizard extends Wizard {
 			Activator.getDefault().logError(ex, Constants.CodeGenerationErrorMessage);
 		} finally {
 			waitingDialog.setVisible(false);
-			waitingDialog.dispose();
 		}
 
 		return ret;


### PR DESCRIPTION
The code generator window is infinitely stuck. This has actually been an issue with demonstrators.

The dispose method is not needed after the wizard is closed and seems to be the blocker. 