### PR TITLE
Remove redundant ruleset listed in preferences

### DIFF
--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/StaticAnalyzerPreferences.java
@@ -181,6 +181,13 @@ public class StaticAnalyzerPreferences extends PreferenceListener {
 		rulesURL.getColumn().setWidth(200);
 
 		listOfRulesets = getRulesetsFromPrefs();
+		
+		//remove BC-JCA provider ruleset from ruleset's table to not have conflict with JCA ruleset
+		for (Ruleset ruleset : listOfRulesets) {
+			if (ruleset.getFolderName().equals("BouncyCastle-JCA")) {
+				listOfRulesets.remove(ruleset);
+			}
+		}
 
 		for (Iterator<Ruleset> itr = listOfRulesets.iterator(); itr.hasNext();) {
 			Ruleset ruleset = (Ruleset) itr.next();

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/sootbridge/SootRunner.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/sootbridge/SootRunner.java
@@ -138,6 +138,7 @@ public class SootRunner {
 						rules.add(r.readRule(providerRule));
 					}
 					
+					// If detected provider is BC-JCA, then loading of JCA ruleset is skipped in next code section in order to avoid conflicts between two rulesets
 					if (detectedProvider == "BouncyCastle-JCA") {
 						 bannedRulesets.add("JavaCryptographicArchitecture");
 					}


### PR DESCRIPTION
# Description

This pull request removes the BouncyCastle-JCA ruleset that is listed in the preferences table of rulesets because if both BC-JCA and JCA are checked, then this introduces possible conflicts between the loading of the rules between the aforementioned rulesets. The BC-JCA rules should only be used when the BC provider is used in the code and this must be detected statically through code analysis, and not chosen from the preferences page.

Fixes #419 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested manually in inner Eclipse.

**Test Configuration**:
* Eclipse Version: 2020-06
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

