### PR TITLE
Code generation plugin test failure issue resolved

### DIFF
--- a/plugins/de.cognicrypt.codegenerator.tests/META-INF/MANIFEST.MF
+++ b/plugins/de.cognicrypt.codegenerator.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: de.cognicrypt.codegenerator.tests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: de.cognicrypt.codegenerator;bundle-version="1.0.0"
 Require-Bundle: org.eclipse.jdt.launching,
- de.cognicrypt.core
+ de.cognicrypt.core,
+ org.slf4j.api;bundle-version="1.7.30"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: lib/claferchocoig.jar,src/
 Export-Package: de.cognicrypt.codegenerator

--- a/plugins/de.cognicrypt.codegenerator.tests/pom.xml
+++ b/plugins/de.cognicrypt.codegenerator.tests/pom.xml
@@ -13,7 +13,14 @@
 	<groupId>de.cognicrypt</groupId>
 	<artifactId>de.cognicrypt.codegenerator.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-api</artifactId>
+		    <version>1.7.30</version>
+		</dependency>
 
+	</dependencies>
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
@@ -45,6 +45,7 @@ public class CodeGenLocationSelectionTest {
 		ICompilationUnit outputClass = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName,
 				"Output.java");
 		assertNotNull(outputClass); // check if Output.java is created
+		TestUtils.deleteProject(generatedProject.getProject());
 	}
 
 	/**
@@ -86,6 +87,7 @@ public class CodeGenLocationSelectionTest {
 		ICompilationUnit outputClass = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName,
 				"Output.java");
 		assertNotNull(outputClass); // check if Output.java is created
+		TestUtils.deleteProject(generatedProject.getProject());
 	}
 
 	/**
@@ -120,5 +122,6 @@ public class CodeGenLocationSelectionTest {
 		ICompilationUnit outputClass = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName,
 				"Output.java");
 		assertNull(outputClass); // check if Output.java is not created
+		TestUtils.deleteProject(generatedProject.getProject());
 	}
 }

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenOthersTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenOthersTest.java
@@ -44,6 +44,7 @@ public class CodeGenOthersTest {
 		ICompilationUnit outputClass = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName,
 				"Output.java");
 		assertNotNull(outputClass); // check if Output.java is created
+		TestUtils.deleteProject(generatedProject.getProject());
 	}
 
 	
@@ -83,6 +84,7 @@ public class CodeGenOthersTest {
 		ICompilationUnit outputClass = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName,
 				"Output.java");
 		assertNotNull(outputClass);	// check if Output.java is created
+		TestUtils.deleteProject(generatedProject.getProject());
 	}
 
 //	 /**

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CrySLCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CrySLCodeGenTest.java
@@ -35,7 +35,8 @@ public class CrySLCodeGenTest {
 	public void generateSymEnc() {
 		String template = "secretkeyencryption";
 		try {
-			IResource targetFile = TestUtils.generateJavaClassInJavaProject(TestUtils.createJavaProject("TestProject_SYMENC"), "testPackage", "Test");
+			IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_SYMENC");
+			IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, "testPackage", "Test");
 			CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 			DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 			CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
@@ -53,6 +54,7 @@ public class CrySLCodeGenTest {
 			assertEquals(4, TestUtils.countStatements(encClassUnit, "generateSessionKey"));
 			assertEquals(13, TestUtils.countStatements(encClassUnit, "encrypt"));
 			assertEquals(11, TestUtils.countStatements(encClassUnit, "decrypt"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -89,6 +91,7 @@ public class CrySLCodeGenTest {
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "getKey"));
 			assertEquals(13, TestUtils.countStatements(encClassUnit, "encrypt"));
 			assertEquals(11, TestUtils.countStatements(encClassUnit, "decrypt"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -125,6 +128,7 @@ public class CrySLCodeGenTest {
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "getKey"));
 			assertEquals(15, TestUtils.countStatements(encClassUnit, "encrypt"));
 			assertEquals(13, TestUtils.countStatements(encClassUnit, "decrypt"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -161,6 +165,7 @@ public class CrySLCodeGenTest {
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "getKey"));
 			assertEquals(14, TestUtils.countStatements(encClassUnit, "encrypt"));
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "decrypt"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -199,6 +204,7 @@ public class CrySLCodeGenTest {
 			assertEquals(7, TestUtils.countStatements(encClassUnit, "encryptSessionKey"));
 			assertEquals(13, TestUtils.countStatements(encClassUnit, "encryptData"));
 			assertEquals(11, TestUtils.countStatements(encClassUnit, "decryptData"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -236,6 +242,7 @@ public class CrySLCodeGenTest {
 			assertEquals(7, TestUtils.countStatements(encClassUnit, "encryptSessionKey"));
 			assertEquals(15, TestUtils.countStatements(encClassUnit, "encryptData"));
 			assertEquals(13, TestUtils.countStatements(encClassUnit, "decryptData"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -274,6 +281,7 @@ public class CrySLCodeGenTest {
 			assertEquals(7, TestUtils.countStatements(encClassUnit, "encryptSessionKey"));
 			assertEquals(14, TestUtils.countStatements(encClassUnit, "encryptData"));
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "decryptData"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -289,7 +297,7 @@ public class CrySLCodeGenTest {
 
 	@Test
 	public void generateSecPwd() {
-		String template = "securePassword";
+		String template = "securepassword";
 		try {
 			IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_SecPwd");
 			IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, "testPackage", "Test");
@@ -309,6 +317,7 @@ public class CrySLCodeGenTest {
 			assertEquals(5, TestUtils.countMethods(encClassUnit));
 			assertEquals(12, TestUtils.countStatements(encClassUnit, "createPWHash"));
 			assertEquals(11, TestUtils.countStatements(encClassUnit, "verifyPWHash"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -344,6 +353,7 @@ public class CrySLCodeGenTest {
 			assertEquals(5, TestUtils.countStatements(encClassUnit, "getKey"));
 			assertEquals(8, TestUtils.countStatements(encClassUnit, "sign"));
 			// assertEquals(14, TestUtils.countStatements(encClassUnit, "vfy"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");
@@ -378,6 +388,7 @@ public class CrySLCodeGenTest {
 			assertEquals(2, TestUtils.countMethods(encClassUnit));
 			assertEquals(5, TestUtils.countStatements(encClassUnit, "createHash"));
 			assertEquals(5, TestUtils.countStatements(encClassUnit, "verifyHash"));
+			TestUtils.deleteProject(testJavaProject.getProject());
 		}
 		catch (JavaModelException e) {
 			Activator.getDefault().logError(e, "Could not create Java class in test project.");


### PR DESCRIPTION
Issue - codegenerator.tests plugin's tests failed in CLI. 

# Description
1. Tests failure in CLI due to NullPointerException when activating staticanalyzer bundle.
2. java.lang.AssertionError when running few tests
3. NullPointerException in generateSecPwd test only when run from CLI


Fixes # (issue)
1. Added slf4j dependency
2. Added TestUtils.deleteProject after each test case
3.  The template file name was given as 'securePassword' instead of 'securepassword'
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Eclipse Version:
* Java Version:
* OS:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes

