### PR TITLE
Added authenticated encryption option to Cognicrypt_GEN

### DIFF
--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
@@ -63,10 +63,28 @@ public class EncryptionCodeGenTest {
 				this.encTask.getAdditionalResources());
 		assertTrue(encCheck);
 	}
+	
+	@Test
+	public void testCodeGenerationEncryptionAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionauth", testClassUnit.getResource(), generatorEnc,
+				this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
 
 	@Test
 	public void testCodeGenerationEncryptionHybrid() throws CoreException, IOException {
 		this.configEnc = TestUtils.createCrySLConfiguration("encryptionhybrid", testClassUnit.getResource(),
+				generatorEnc, this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
+	
+	@Test
+	public void testCodeGenerationEncryptionHybridAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionhybridauth", testClassUnit.getResource(),
 				generatorEnc, this.developerProject);
 		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
 				this.encTask.getAdditionalResources());
@@ -81,6 +99,15 @@ public class EncryptionCodeGenTest {
 				this.encTask.getAdditionalResources());
 		assertTrue(encCheck);
 	}
+	
+	@Test
+	public void testCodeGenerationEncryptionFilesAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionfilesauth", testClassUnit.getResource(),
+				generatorEnc, this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
 
 	@Test
 	public void testCodeGenerationEncryptionHybridFiles() throws CoreException, IOException {
@@ -90,10 +117,28 @@ public class EncryptionCodeGenTest {
 				this.encTask.getAdditionalResources());
 		assertTrue(encCheck);
 	}
+	
+	@Test
+	public void testCodeGenerationEncryptionHybridFilesAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionhybridfilesauth", testClassUnit.getResource(),
+				generatorEnc, this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
 
 	@Test
 	public void testCodeGenerationEncryptionHybridStrings() throws CoreException, IOException {
 		this.configEnc = TestUtils.createCrySLConfiguration("encryptionhybridstrings", testClassUnit.getResource(),
+				generatorEnc, this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
+	
+	@Test
+	public void testCodeGenerationEncryptionHybridStringsAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionhybridstringsauth", testClassUnit.getResource(),
 				generatorEnc, this.developerProject);
 		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
 				this.encTask.getAdditionalResources());
@@ -109,6 +154,16 @@ public class EncryptionCodeGenTest {
 		assertTrue(encCheck);
 	}
 
+	@Test
+	public void testCodeGenerationEncryptionStringsAuth() throws CoreException, IOException {
+		this.configEnc = TestUtils.createCrySLConfiguration("encryptionstringsauth", testClassUnit.getResource(),
+				generatorEnc, this.developerProject);
+		final boolean encCheck = this.generatorEnc.generateCodeTemplates(this.configEnc,
+				this.encTask.getAdditionalResources());
+		assertTrue(encCheck);
+	}
+
+	
 	@Test
 	public void testCodeGenerationSecretKeyEncryption() throws CoreException, IOException {
 		this.configEnc = TestUtils.createCrySLConfiguration("secretkeyencryption", testClassUnit.getResource(),

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionauth/SecureEncryptor.java
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionauth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey getKey(char[] pwd) {
+		byte[] salt = new byte[32];
+		
+		javax.crypto.SecretKey encryptionKey = null;
+		
+		int keysize = 128;
+		
+		CrySLCodeGenerator.getInstance().includeClass("java.security.SecureRandom").addParameter(salt, "next").includeClass("javax.crypto.spec.PBEKeySpec")
+			.addParameter(pwd, "password").addParameter(keysize, "keylength").includeClass("javax.crypto.SecretKeyFactory").includeClass("javax.crypto.SecretKey")
+			.includeClass("javax.crypto.spec.SecretKeySpec").addParameter(encryptionKey, "this").generate();
+
+		return encryptionKey;
+	}
+	
+	public javax.crypto.spec.SecretKeySpec getSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;
+		
+	}
+	
+	public byte[] encrypt(byte[] plaintext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+		
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plaintext, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+        return ciphertext;	
+	}
+
+	public byte[] decrypt(byte[] ciphertext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertext, "plainText").addParameter(plaintext, "ciphertext").generate();
+
+		return plaintext;
+	}
+
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionfilesauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionfilesauth/SecureEncryptor.java
@@ -1,0 +1,100 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionfilesauth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey getKey(char[] pwd) {
+		byte[] salt = new byte[32];
+		
+		javax.crypto.SecretKey encryptionKey = null;
+		
+		int keysize = 128;
+		
+		CrySLCodeGenerator.getInstance().includeClass("java.security.SecureRandom").addParameter(salt, "next").includeClass("javax.crypto.spec.PBEKeySpec")
+			.addParameter(pwd, "password").addParameter(keysize, "keylength").includeClass("javax.crypto.SecretKeyFactory").includeClass("javax.crypto.SecretKey")
+			.includeClass("javax.crypto.spec.SecretKeySpec").addParameter(encryptionKey, "this").generate();
+
+		return encryptionKey;
+	}
+	
+	public javax.crypto.spec.SecretKeySpec getSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;
+		
+	}
+	
+	public java.io.File encrypt(java.io.File plaintext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+		
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plaintextFile = Files.readAllBytes(Paths.get(plaintext.getAbsolutePath()));
+		
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plaintextFile, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+		Files.write(Paths.get(plaintext.getAbsolutePath()), ciphertext);
+		return plaintext;
+	}
+
+	public java.io.File decrypt(java.io.File ciphertext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+		
+		byte[] ciphertextFile = Files.readAllBytes(Paths.get(ciphertext.getAbsolutePath()));
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertextFile, "plainText").addParameter(plaintext, "ciphertext").generate();
+
+		Files.write(Paths.get(ciphertext.getAbsolutePath()), plaintext);
+		return ciphertext;
+	}
+
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridauth/SecureEncryptor.java
@@ -1,0 +1,97 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionhybridauth;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey generateSessionKey() throws NoSuchAlgorithmException {
+		javax.crypto.SecretKey sessionKey = null;
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.KeyGenerator").addParameter(sessionKey, "key").generate();
+		return sessionKey;
+	}
+
+	public java.security.KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+		java.security.KeyPair keyPair = null;
+		CrySLCodeGenerator.getInstance().includeClass("java.security.KeyPairGenerator").addParameter(keyPair, "kp");
+		return keyPair;
+	}
+
+	public javax.crypto.spec.SecretKeySpec generateSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;
+		
+	}
+	
+	public byte[] encryptSessionKey(javax.crypto.SecretKey sessionKey, java.security.KeyPair keyPair) throws GeneralSecurityException {
+		byte[] wrappedKeyBytes = null;
+		int mode = Cipher.WRAP_MODE;
+		java.security.PublicKey publicKey = keyPair.getPublic();
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.Cipher").addParameter(mode, "encmode").addParameter(publicKey, "key").addParameter(sessionKey, "wrappedKey")
+			.addParameter(wrappedKeyBytes, "wrappedKeyBytes").generate();
+		return wrappedKeyBytes;
+	}
+
+	public byte[] encryptData(byte[] plaintext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) {
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plaintext, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+        return ciphertext;	
+	}
+
+	public byte[] decryptData(byte[] ciphertext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertext, "plainText").addParameter(plaintext, "ciphertext").generate();
+
+		return plaintext;
+	}
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridfilesauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridfilesauth/SecureEncryptor.java
@@ -1,0 +1,106 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionhybridfilesauth;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey generateSessionKey() throws NoSuchAlgorithmException {
+		javax.crypto.SecretKey sessionKey = null;
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.KeyGenerator").addParameter(sessionKey, "key").generate();
+		return sessionKey;
+	}
+
+	public java.security.KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+		java.security.KeyPair keyPair = null;
+		CrySLCodeGenerator.getInstance().includeClass("java.security.KeyPairGenerator").addParameter(keyPair, "kp");
+		return keyPair;
+	}
+	
+	public javax.crypto.spec.SecretKeySpec generateSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;
+		
+	}
+
+	public byte[] encryptSessionKey(javax.crypto.SecretKey sessionKey, java.security.KeyPair keyPair) throws GeneralSecurityException {
+		byte[] wrappedKeyBytes = null;
+		int mode = Cipher.WRAP_MODE;
+		java.security.PublicKey publicKey = keyPair.getPublic();
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.Cipher").addParameter(mode, "encmode").addParameter(publicKey, "key").addParameter(sessionKey, "wrappedKey")
+			.addParameter(wrappedKeyBytes, "wrappedKeyBytes").generate();
+		return wrappedKeyBytes;
+	}
+
+	public java.io.File encryptData(java.io.File plaintext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+		
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plaintextFile = Files.readAllBytes(Paths.get(plaintext.getAbsolutePath()));
+		
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plaintextFile, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+		Files.write(Paths.get(plaintext.getAbsolutePath()), ciphertext);
+		return plaintext;
+	}
+
+	public java.io.File decryptData(java.io.File ciphertext, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+		
+		byte[] ciphertextFile = Files.readAllBytes(Paths.get(ciphertext.getAbsolutePath()));
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertextFile, "plainText").addParameter(plaintext, "ciphertext").generate();
+		
+		Files.write(Paths.get(ciphertext.getAbsolutePath()), plaintext);
+		return ciphertext;
+	}
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridstringsauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionhybridstringsauth/SecureEncryptor.java
@@ -1,0 +1,105 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionhybridstringsauth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey generateSessionKey() throws NoSuchAlgorithmException {
+		javax.crypto.SecretKey sessionKey = null;
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.KeyGenerator").addParameter(sessionKey, "key").generate();
+		return sessionKey;
+	}
+
+	public java.security.KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+		java.security.KeyPair keyPair = null;
+		CrySLCodeGenerator.getInstance().includeClass("java.security.KeyPairGenerator").addParameter(keyPair, "kp");
+		return keyPair;
+	}
+
+	public byte[] encryptSessionKey(javax.crypto.SecretKey sessionKey, java.security.KeyPair keyPair) throws GeneralSecurityException {
+		byte[] wrappedKeyBytes = null;
+		int mode = Cipher.WRAP_MODE;
+		java.security.PublicKey publicKey = keyPair.getPublic();
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.Cipher").addParameter(mode, "encmode").addParameter(publicKey, "key").addParameter(sessionKey, "wrappedKey")
+			.addParameter(wrappedKeyBytes, "wrappedKeyBytes").generate();
+		return wrappedKeyBytes;
+	}
+	
+	public javax.crypto.spec.SecretKeySpec getSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;	
+	}
+
+	public java.lang.String encryptData(java.lang.String text, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+		
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plainText = text.getBytes(StandardCharsets.UTF_8);
+		
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plainText, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+        return Base64.getEncoder().encodeToString(ciphertext);	
+	}
+
+	public java.lang.String decryptData(java.lang.String encodedString, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+		
+		byte[] ciphertext = Base64.getDecoder().decode(encodedString);
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertext, "plainText").addParameter(plaintext, "ciphertext").generate();
+
+		return new String(plaintext, StandardCharsets.UTF_8);
+	}
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionstringsauth/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionstringsauth/SecureEncryptor.java
@@ -1,0 +1,96 @@
+/********************************************************************************
+ * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+package de.cognicrypt.codegenerator.crysl.templates.encryptionstringsauth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+
+import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
+
+public class SecureEncryptor {
+
+	public javax.crypto.SecretKey getKey(char[] pwd) {
+		byte[] salt = new byte[32];
+		
+		javax.crypto.SecretKey encryptionKey = null;
+		
+		int keysize = 128;
+		
+		CrySLCodeGenerator.getInstance().includeClass("java.security.SecureRandom").addParameter(salt, "next").includeClass("javax.crypto.spec.PBEKeySpec")
+			.addParameter(pwd, "password").addParameter(keysize, "keylength").includeClass("javax.crypto.SecretKeyFactory").includeClass("javax.crypto.SecretKey")
+			.includeClass("javax.crypto.spec.SecretKeySpec").addParameter(encryptionKey, "this").generate();
+
+		return encryptionKey;
+	}
+	
+	public javax.crypto.spec.SecretKeySpec getSecretKey(javax.crypto.SecretKey secretKey){
+		
+		javax.crypto.spec.SecretKeySpec secretKeySpec = null;
+		
+		byte[] key = secretKey.getEncoded();
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.SecretKeySpec").addParameter(key, "keyMaterial")
+		.addParameter(secretKeySpec, "this").generate();
+
+		return secretKeySpec;
+		
+	}
+	
+	public java.lang.String encrypt(java.lang.String text, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+		
+		int mode = Cipher.ENCRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+
+		byte[] plainText = text.getBytes(StandardCharsets.UTF_8);
+		
+		byte[] ciphertext = null;
+
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+			.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+			.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+			.addParameter(mode, "encmode").addParameter(keySpec, "key")
+			.addParameter(plainText, "plainText").addParameter(ciphertext, "ciphertext").generate();
+
+        return Base64.getEncoder().encodeToString(ciphertext);	
+	}
+
+	public java.lang.String decrypt(java.lang.String encodedString, javax.crypto.SecretKey secretKey, byte[] ivBytes,
+		javax.crypto.spec.SecretKeySpec keySpec) throws IOException {
+
+		int mode = Cipher.DECRYPT_MODE;
+		
+		int keysize = 128;
+		
+		java.lang.String transformation = "AES/GCM/NoPadding";
+		
+		byte[] ciphertext = Base64.getDecoder().decode(encodedString);
+
+		byte[] plaintext = null;
+		
+		
+		CrySLCodeGenerator.getInstance().includeClass("javax.crypto.spec.GCMParameterSpec")
+		.addParameter(keysize, "tLen").addParameter(ivBytes, "src")
+		.includeClass("javax.crypto.Cipher").addParameter(transformation, "transformation")
+		.addParameter(mode, "encmode").addParameter(keySpec, "key")
+		.addParameter(ciphertext, "plainText").addParameter(plaintext, "ciphertext").generate();
+
+		return new String(plaintext, StandardCharsets.UTF_8);
+	}
+
+
+}

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
@@ -14,8 +14,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.swing.JDialog;
@@ -124,8 +128,13 @@ public class AltConfigWizard extends Wizard {
 		//Only case that is left: BeginnerTaskQuestionPage
 		final BeginnerTaskQuestionPage curQuestionPage = (BeginnerTaskQuestionPage) currentPage;
 		final HashMap<Question, Answer> curQuestionAnswerMap = curQuestionPage.getMap();
-
-		for (final Entry<Question, Answer> entry : curQuestionAnswerMap.entrySet()) {
+		
+		List<Map.Entry<Question, Answer>> curQuestionAnswerList = new LinkedList<Map.Entry<Question, Answer>>(curQuestionAnswerMap.entrySet());
+		Collections.sort(
+			curQuestionAnswerList,
+            (i1, i2) -> Integer.compare(i1.getKey().getId(), i2.getKey().getId()));
+		
+		for (final Map.Entry<Question, Answer> entry : curQuestionAnswerList) {
 			this.constraints.put(entry.getKey(), entry.getValue());
 		}
 

--- a/plugins/de.cognicrypt.codegenerator/src/main/resources/TaskDesc/Encryption.json
+++ b/plugins/de.cognicrypt.codegenerator/src/main/resources/TaskDesc/Encryption.json
@@ -1,6 +1,7 @@
 [{
   "id": "0",
-  "content": [{
+  "content": [
+	 {
       "id": "0",
       "element": "radio",
       "questionText": "Which method of communication would you prefer to use for key exchange 2?",
@@ -45,11 +46,26 @@
         {
           "value": "Other/Do not know",
            "option": "",
-          "nextID": "-1",
           "defaultAnswer": true
         }
       ]
-    }
+     },
+     {
+     "id": "2",
+     "element": "radio",
+     "questionText": "Which type of encryption do you prefer?",
+     "answers": [{
+          "value": "Symmetric Encryption",
+          "option": "",
+		  "defaultAnswer": true
+        },
+        {
+          "value": "Authenticated Encryption",
+          "option": "auth",
+		  "nextID": "-1"
+        }
+      ]
+     }
   ],
   "nextID": "-1"
 }]


### PR DESCRIPTION
# Description

1. Added an option to choose symmetric encryption or authenticated encryption during code generation. AES cipher with GCM mode was used to incorporate authenticated encryption. 

2. Corrected inconsistency with the code template name generation when the order of option selected by the user varies.

Fixes # (issue)
Issue 146
Issue 398

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added unit tests cases in codegenerator.tests and also performed manual testing.
**Test Configuration**:
* Eclipse Version: 2020-12 (4.18.0)
* Java Version: 8
* OS: Windows


