### PR TITLE
Fix casting error in CrySLParser.java on cryslhandler

### DIFF
--- a/features/de.cognicrypt.codegenerator.feature/feature.xml
+++ b/features/de.cognicrypt.codegenerator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.cognicrypt.codegenerator.feature"
       label="CogniCrypt Crypto-API Example Generator"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Technical University Darmstadt; Paderborn University">
 
    <description url="https://cognicrypt.de">
@@ -109,7 +109,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
       <import plugin="org.eclipse.ui.editors"/>
       <import plugin="org.eclipse.compare"/>
       <import plugin="org.apache.commons.io" version="2.2.0" match="greaterOrEqual"/>
-      <import plugin="de.cognicrypt.core" version="1.0.0" match="perfect"/>
+      <import plugin="de.cognicrypt.core" version="1.0.1" match="perfect"/>
       <import plugin="org.eclipse.jdt.launching"/>
    </requires>
 
@@ -117,7 +117,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
          id="de.cognicrypt.codegenerator"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/de.cognicrypt.codegenerator.feature/pom.xml
+++ b/features/de.cognicrypt.codegenerator.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	</project>

--- a/features/de.cognicrypt.core.feature/feature.xml
+++ b/features/de.cognicrypt.core.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.cognicrypt.core.feature"
       label="CogniCrypt Core"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Technical University Darmstadt; Paderborn University">
 
    <description url="https://cognicrypt.de">
@@ -118,7 +118,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
          id="de.cognicrypt.core"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/de.cognicrypt.core.feature/pom.xml
+++ b/features/de.cognicrypt.core.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>

--- a/features/de.cognicrypt.cryslhandler.feature/feature.xml
+++ b/features/de.cognicrypt.cryslhandler.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.cognicrypt.cryslhandler.feature"
       label="CogniCrypt CrySL Handler"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Technical University Darmstadt, Paderborn University">
 
    <description url="https://cognicrypt.de">
@@ -115,7 +115,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
       <import plugin="de.darmstadt.tu.crossing.CrySL.ui" version="2.0.0" match="perfect"/>
       <import plugin="de.darmstadt.tu.crossing.CrySL" version="2.0.0" match="perfect"/>
       <import plugin="de.darmstadt.tu.crossing.CrySL.ide" version="2.0.0" match="perfect"/>
-      <import plugin="de.cognicrypt.core" version="1.0.0" match="perfect"/>
+      <import plugin="de.cognicrypt.core" version="1.0.1" match="perfect"/>
       <import plugin="org.junit"/>
    </requires>
 
@@ -123,7 +123,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
          id="de.cognicrypt.crysl.handler"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/de.cognicrypt.cryslhandler.feature/pom.xml
+++ b/features/de.cognicrypt.cryslhandler.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 </project>

--- a/features/de.cognicrypt.staticanalyzer.feature/feature.xml
+++ b/features/de.cognicrypt.staticanalyzer.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.cognicrypt.staticanalyzer.feature"
       label="CogniCrypt Crypto-API Misuse Detector"
-      version="1.0.0"
+      version="1.0.1"
       provider-name="Technical University Darmstadt; Paderborn University">
 
    <description url="https://cognicrypt.de">
@@ -107,7 +107,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
       <import plugin="org.eclipse.jface.text" version="3.11.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.common"/>
       <import plugin="org.eclipse.m2e.maven.runtime"/>
-      <import plugin="de.cognicrypt.core" version="1.0.0" match="perfect"/>
+      <import plugin="de.cognicrypt.core" version="1.0.1" match="perfect"/>
       <import plugin="com.google.guava"/>
    </requires>
 
@@ -115,7 +115,7 @@ Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives n
          id="de.cognicrypt.staticanalyzer"
          download-size="0"
          install-size="0"
-         version="1.0.0"
+         version="1.0.1"
          unpack="false"/>
 
 </feature>

--- a/features/de.cognicrypt.staticanalyzer.feature/pom.xml
+++ b/features/de.cognicrypt.staticanalyzer.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>de.cognicrypt</groupId>

--- a/plugins/de.cognicrypt.codegenerator.tests/pom.xml
+++ b/plugins/de.cognicrypt.codegenerator.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/de.cognicrypt.codegenerator/pom.xml
+++ b/plugins/de.cognicrypt.codegenerator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/de.cognicrypt.core/pom.xml
+++ b/plugins/de.cognicrypt.core/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/plugins/de.cognicrypt.crysl.handler/pom.xml
+++ b/plugins/de.cognicrypt.crysl.handler/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/de.cognicrypt.crysl.handler/src/main/java/de/cognicrypt/crysl/reader/CrySLParser.java
+++ b/plugins/de.cognicrypt.crysl.handler/src/main/java/de/cognicrypt/crysl/reader/CrySLParser.java
@@ -340,7 +340,7 @@ public class CrySLParser {
 	private CrySLPredicate extractReqPred(final ReqPred pred) {
 		final List<ICrySLPredicateParameter> variables = new ArrayList<>();
 		PredLit innerPred = (PredLit) pred;
-		final Constraint conditional = innerPred.getCons();
+		final Constraint conditional = (Constraint) innerPred.getCons();
 		if (innerPred.getPred().getParList() != null) {
 			for (final SuPar var : innerPred.getPred().getParList().getParameters()) {
 				if (var.getVal() != null) {

--- a/plugins/de.cognicrypt.integrator.primitive/pom.xml
+++ b/plugins/de.cognicrypt.integrator.primitive/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/de.cognicrypt.integrator.task/pom.xml
+++ b/plugins/de.cognicrypt.integrator.task/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/plugins/de.cognicrypt.staticanalyzer/pom.xml
+++ b/plugins/de.cognicrypt.staticanalyzer/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>de.cognicrypt</groupId>
     <artifactId>de.cognicrypt.parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.cognicrypt</groupId>
   <artifactId>de.cognicrypt.parent</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/de.cognicrypt.codegenerator.feature_1.0.0.jar" id="de.cognicrypt.codegenerator.feature" version="1.0.0">
+   <feature url="features/de.cognicrypt.codegenerator.feature_1.0.1.jar" id="de.cognicrypt.codegenerator.feature" version="1.0.1">
       <category name="de.cognicrypt.catergory"/>
    </feature>
-   <feature url="features/de.cognicrypt.staticanalyzer.feature_1.0.0.jar" id="de.cognicrypt.staticanalyzer.feature" version="1.0.0">
+   <feature url="features/de.cognicrypt.staticanalyzer.feature_1.0.1.jar" id="de.cognicrypt.staticanalyzer.feature" version="1.0.1">
       <category name="de.cognicrypt.catergory"/>
    </feature>
-   <feature url="features/de.cognicrypt.cryslhandler.feature_1.0.0.jar" id="de.cognicrypt.cryslhandler.feature" version="1.0.0">
+   <feature url="features/de.cognicrypt.cryslhandler.feature_1.0.1.jar" id="de.cognicrypt.cryslhandler.feature" version="1.0.1">
       <category name="de.cognicrypt.catergory"/>
    </feature>
    <feature url="features/de.darmstadt.tu.crossing.CrySL.feature_2.0.0.jar" id="de.darmstadt.tu.crossing.CrySL.feature" version="2.0.0">
       <category name="de.darmstadt.tu.crysl"/>
    </feature>
-   <feature url="features/de.cognicrypt.core.feature_1.0.0.jar" id="de.cognicrypt.core.feature" version="1.0.0">
+   <feature url="features/de.cognicrypt.core.feature_1.0.1.jar" id="de.cognicrypt.core.feature" version="1.0.1">
       <category name="de.cognicrypt.catergory"/>
    </feature>
    <category-def name="de.cognicrypt.catergory" label="CogniCrypt"/>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>de.cognicrypt</groupId>
 		<artifactId>de.cognicrypt.parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<profiles>


### PR DESCRIPTION
# Description

This PR fixes a casting error on _cryslhandler_ module because the static analysis and code generation components of CogniCrypt were not working.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual tests have been performed for the static analysis part, as well as the code generation one.

**Test Configuration**:
* Eclipse Version: 2020-06
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

