### PR TITLE
Update Jenkins file to fix build error in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn clean install'
+                sh 'mvn clean package -X -e'
             }
         }
         stage('Publish Snapshot'){


### PR DESCRIPTION
# Description

The Jenkins CI fails when we use `mvn clean install` in the build stage. The failing is nondeterministic, meaning that sometimes the build fails and sometimes not. Since the reason is not yet found, we have to revert to using `mvn clean package`. We should only use `mvn clean install` locally at our machines since this command is more inclusive and also runs the JUnit tests.

Related to issue #431

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The build has been tested in my local machine and it completes successfully.

**Test Configuration**:
* Eclipse Version: 2020-09
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

