### PR TITLE
Improve wizard interface for the task selection page

### DIFF
--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CogniCryptWizardDialog.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CogniCryptWizardDialog.java
@@ -13,6 +13,7 @@ package de.cognicrypt.codegenerator.wizard;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
@@ -21,6 +22,7 @@ public class CogniCryptWizardDialog extends WizardDialog {
 
 	public CogniCryptWizardDialog(final Shell parentShell, final IWizard newWizard) {
 		super(parentShell, newWizard);
+		this.setPageSize(new Point(400, 600));
 	}
 
 	@Override
@@ -29,5 +31,4 @@ public class CogniCryptWizardDialog extends WizardDialog {
 		final Button finishButton = getButton(IDialogConstants.FINISH_ID);
 		finishButton.setText("Generate");
 	}
-
 }

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
@@ -24,10 +24,11 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
@@ -79,8 +80,6 @@ public class TaskSelectionPage extends WizardPage {
 		
 		// Task items are displayed as a list in the listOfTaskItems
 		final RowLayout rl = new RowLayout(SWT.VERTICAL);
-		rl.spacing = 5;
-		rl.justify = true;
 		this.listOfTaskItems.setLayout(rl);
 		
 		// add tasks items to listOfTaskItems
@@ -91,8 +90,9 @@ public class TaskSelectionPage extends WizardPage {
 		sc.setContent(this.listOfTaskItems);
 		sc.setExpandHorizontal(true);
 		sc.setExpandVertical(true);
+		sc.setAlwaysShowScrollBars(true);
 		sc.setMinSize(this.listOfTaskItems.computeSize(SWT.DEFAULT, SWT.DEFAULT));
-		setControl(sc);
+		this.setControl(sc);
 	}
 
 	@Override
@@ -165,6 +165,7 @@ public class TaskSelectionPage extends WizardPage {
 			// listOfTaskItems is filled with a Group, which has a two row grid layout.
 			super(listOfTaskItems, SWT.FILL);
 			this.setLayout(new GridLayout(1, false));
+			//this.setLayoutData(new RowData(SWT.FILL, SWT.DEFAULT));
 			final Group group = new Group(this, SWT.FILL | SWT.SHADOW_ETCHED_OUT);
 			group.setLayout(new GridLayout(2, false));
 			
@@ -194,6 +195,7 @@ public class TaskSelectionPage extends WizardPage {
 			final Label taskdescr = new Label(descr, SWT.WRAP);
 			final Font largeFont = new Font( descr.getDisplay(), new FontData( "Arial", 14, SWT.NONE ) );
 			taskdescr.setFont(largeFont);
+			
 			final Color gray = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
 			taskdescr.setForeground(gray);
 			RowData rd_taskdescr = new RowData();
@@ -212,6 +214,19 @@ public class TaskSelectionPage extends WizardPage {
 			descr.addListener(SWT.MouseUp, listener);
 			title.addListener(SWT.MouseUp, listener);
 			taskdescr.addListener(SWT.MouseUp, listener);
+			
+			// add dispose listener (best practice: https://www.eclipse.org/articles/swt-design-2/swt-design-2.html)
+			this.addDisposeListener(new DisposeListener() {
+				
+				@Override
+				public void widgetDisposed(DisposeEvent event) {
+					boldFont.dispose();
+					largeFont.dispose();
+					taskImage.dispose();
+				}
+			});
+			
+			
 		}
 		
 		public void select() {

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
@@ -35,6 +36,7 @@ import org.eclipse.swt.layout.RowData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -52,7 +54,7 @@ public class TaskSelectionPage extends WizardPage {
 	private TaskItemComposite selectedTaskItem = null;
 	private Composite listOfTaskItems; // Row Layout Composite that holds task items composite
 	private List<TaskItemComposite> taskItems = new ArrayList<TaskItemComposite>(); // ArrayList of all tasks item composite
-
+	
 	public TaskSelectionPage() {
 		super(Constants.SELECT_TASK);
 		setTitle(Constants.TASK_LIST);
@@ -77,6 +79,8 @@ public class TaskSelectionPage extends WizardPage {
 		
 		// Task items are displayed as a list in the listOfTaskItems
 		final RowLayout rl = new RowLayout(SWT.VERTICAL);
+		rl.spacing = 5;
+		rl.justify = true;
 		this.listOfTaskItems.setLayout(rl);
 		
 		// add tasks items to listOfTaskItems
@@ -158,12 +162,14 @@ public class TaskSelectionPage extends WizardPage {
 
 		TaskItemComposite(final Composite listOfTaskItems, Task task) {
 			
-			// listOfTaskItems with 2 columns
+			// listOfTaskItems is filled with a Group, which has a two row grid layout.
 			super(listOfTaskItems, SWT.FILL);
-			this.setLayout(new GridLayout(2, false));
+			this.setLayout(new GridLayout(1, false));
+			final Group group = new Group(this, SWT.FILL | SWT.SHADOW_ETCHED_OUT);
+			group.setLayout(new GridLayout(2, false));
 			
-			// First column gets a button with the image
-			this.button = new Button(this, SWT.TOGGLE);
+			// First column gets a radio button with the image
+			this.button = new Button(group, SWT.TOGGLE | SWT.RADIO);
 			this.button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 			final Image taskImage = loadImage(task.getImage());
 			if(taskImage == null) {
@@ -174,7 +180,7 @@ public class TaskSelectionPage extends WizardPage {
 			this.button.setImage(taskImage);
 			
 			// Second column gets group with title and description
-			final Group descr = new Group(this, SWT.FILL);
+			final Composite descr = new Composite(group, SWT.FILL);
 			descr.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
 			descr.setLayout(new RowLayout(SWT.VERTICAL));
 			
@@ -186,10 +192,10 @@ public class TaskSelectionPage extends WizardPage {
 			
 			// description
 			final Label taskdescr = new Label(descr, SWT.WRAP);
-			final Color taskdescrColor = new Color(taskdescr.getDisplay(), 100, 100, 100);
 			final Font largeFont = new Font( descr.getDisplay(), new FontData( "Arial", 14, SWT.NONE ) );
 			taskdescr.setFont(largeFont);
-			taskdescr.setForeground(taskdescrColor);
+			final Color gray = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
+			taskdescr.setForeground(gray);
 			RowData rd_taskdescr = new RowData();
 			rd_taskdescr.width = 400;
 			taskdescr.setLayoutData(rd_taskdescr);

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/TaskSelectionPage.java
@@ -33,8 +33,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.layout.RowData;
-import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
@@ -67,8 +65,8 @@ public class TaskSelectionPage extends WizardPage {
 	public void createControl(final Composite parent) {
 
 		// Make the content able to scroll
-		final ScrolledComposite sc = new ScrolledComposite(parent, SWT.H_SCROLL | SWT.V_SCROLL);
-		sc.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		final ScrolledComposite sc = new ScrolledComposite(parent, SWT.V_SCROLL);
+		sc.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, true));
 
 		// To display the Help view after clicking the help icon
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(sc, "de.cognicrypt.codegenerator.TaskSelectionHelp");
@@ -76,11 +74,11 @@ public class TaskSelectionPage extends WizardPage {
 		// listOfTaskItems will hold the selection items for all tasks
 		// it is attached in the ScrolledComposite
 		this.listOfTaskItems = new Composite(sc, SWT.NONE);
-		this.listOfTaskItems.setBounds(10, 10, 400, 200);
 		
 		// Task items are displayed as a list in the listOfTaskItems
-		final RowLayout rl = new RowLayout(SWT.VERTICAL);
+		final GridLayout rl = new GridLayout(1, false);
 		this.listOfTaskItems.setLayout(rl);
+		this.listOfTaskItems.setLayoutData(new GridData(GridData.FILL, GridData.BEGINNING, true, false));
 		
 		// add tasks items to listOfTaskItems
 		for (Task ccTask: TaskJSONReader.getTasks()) {
@@ -91,7 +89,9 @@ public class TaskSelectionPage extends WizardPage {
 		sc.setExpandHorizontal(true);
 		sc.setExpandVertical(true);
 		sc.setAlwaysShowScrollBars(true);
-		sc.setMinSize(this.listOfTaskItems.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+		sc.addListener( SWT.Resize, event -> {
+			 sc.setMinSize(this.listOfTaskItems.computeSize( getShell().getClientArea().width - sc.getVerticalBar().getSize().x, SWT.DEFAULT));
+			} );
 		this.setControl(sc);
 	}
 
@@ -163,15 +163,16 @@ public class TaskSelectionPage extends WizardPage {
 		TaskItemComposite(final Composite listOfTaskItems, Task task) {
 			
 			// listOfTaskItems is filled with a Group, which has a two row grid layout.
-			super(listOfTaskItems, SWT.FILL);
+			super(listOfTaskItems, SWT.NONE);
 			this.setLayout(new GridLayout(1, false));
-			//this.setLayoutData(new RowData(SWT.FILL, SWT.DEFAULT));
-			final Group group = new Group(this, SWT.FILL | SWT.SHADOW_ETCHED_OUT);
+			this.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+			final Group group = new Group(this, SWT.SHADOW_ETCHED_OUT);
 			group.setLayout(new GridLayout(2, false));
+			group.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
 			
 			// First column gets a radio button with the image
 			this.button = new Button(group, SWT.TOGGLE | SWT.RADIO);
-			this.button.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+			this.button.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 			final Image taskImage = loadImage(task.getImage());
 			if(taskImage == null) {
 				throw new IllegalArgumentException("Missing Image for Task: " + task.getName());
@@ -181,9 +182,9 @@ public class TaskSelectionPage extends WizardPage {
 			this.button.setImage(taskImage);
 			
 			// Second column gets group with title and description
-			final Composite descr = new Composite(group, SWT.FILL);
-			descr.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
-			descr.setLayout(new RowLayout(SWT.VERTICAL));
+			final Composite descr = new Composite(group, SWT.NONE);
+			descr.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));
+			descr.setLayout(new GridLayout(1, false));
 			
 			// title
 			final Label title = new Label(descr, SWT.WRAP);
@@ -198,10 +199,8 @@ public class TaskSelectionPage extends WizardPage {
 			
 			final Color gray = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GRAY);
 			taskdescr.setForeground(gray);
-			RowData rd_taskdescr = new RowData();
-			rd_taskdescr.width = 400;
-			taskdescr.setLayoutData(rd_taskdescr);
 			taskdescr.setText(task.getTaskDescription());
+			taskdescr.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 			taskdescr.pack();
 			
 			this.task = task;


### PR DESCRIPTION
Signed-off-by: Marvin Philipp Vogel <marvinv@mail.uni-paderborn.de>

# Description
This commit changes the gui for the code generators task selection. It shows all titles and descriptions of the task next to their buttons and not only the button, but also the text is clickable.
It also removes the arbitrarily default selected task, so the user has to actively choose a task before he could continue.

**Screenshot of old page:**
<img width="751" alt="Old" src="https://user-images.githubusercontent.com/91740473/137137985-1f10a8f3-ef55-4c8e-beb5-0c7b5f78aa45.png">

**Screenshot of new page:**
<img width="680" alt="New" src="https://user-images.githubusercontent.com/91740473/137138026-138f81af-0929-48a8-9491-ea06198e2ea9.png">


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - pictures of the page would need an update

# How Has This Been Tested?

- [x] Manually checking all navigation options and resizing window

**Test Configuration**:
* Eclipse Version: 4.21.0
* Java Version: 1.8
* OS: macOS

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

