### PR TITLE
Fix build failure in Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn -U clean package -X -e'
+                sh 'mvn clean install -U -DskipTests=true'
             }
         }
         stage('Publish Snapshot'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
 
     tools {
-        maven 'Maven 3.6.3'
+        maven 'apache-maven-latest'
         jdk 'oracle-jdk8-latest'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn clean package -X -e'
+                sh 'mvn -U clean package -X -e'
             }
         }
         stage('Publish Snapshot'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
 
     tools {
-        maven 'apache-maven-latest'
+        maven 'Maven 3.6.3'
         jdk 'oracle-jdk8-latest'
     }
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>1.6.0</version>
+				<version>1.4.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>1.6.0</version>
+				<version>2.2.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>1.4.0</version>
+				<version>1.6.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
# Description

Jenkins CI is failing due to a dependency not being resolved. Added the `-U` flag in the build command to update all dependencies on the server, so that this broken dependency is updated as well. After the build is fixed, we can close this PR, as it does not need to be merged into develop branch

Fixes #448 

