### PR TITLE
Update Maven version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,14 +2,14 @@ pipeline {
     agent any
 
     tools {
-        maven 'apache-maven-latest'
+        maven 'Maven 3.6.3'
         jdk 'oracle-jdk8-latest'
     }
 
     stages {
         stage('Build') {
             steps {
-                sh 'mvn clean package -X -e'
+                sh 'mvn clean install -U'
             }
         }
         stage('Publish Snapshot'){


### PR DESCRIPTION
# Description

The Jenkins CI fails at the moment. Running the build with the Maven version 3.6.3 does not result in errors atleast in Github Actions. This PR changes the Jenkins file to use this Maven version 3.6.3 as it might resolve the build error. The flag -U is included to update all dependencies.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Eclipse Version:
* Java Version:
* OS:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

