### PR TITLE
Fix for issue #457

### DIFF
--- a/plugins/de.cognicrypt.crysl.handler/src/main/java/de/cognicrypt/crysl/reader/CrySLParser.java
+++ b/plugins/de.cognicrypt.crysl.handler/src/main/java/de/cognicrypt/crysl/reader/CrySLParser.java
@@ -339,7 +339,6 @@ public class CrySLParser {
 	}
 
 	private CrySLPredicate extractReqPred(final ReqPred pred) {
-		final List<ICrySLPredicateParameter> variables = new ArrayList<>();
 		PredLit innerPred = (PredLit) pred;
 		EObject cons = innerPred.getCons();
 		ISLConstraint conditional = null;
@@ -348,27 +347,8 @@ public class CrySLParser {
 		} else if (cons instanceof Pred) {
 			conditional = getPredicate((Pred) cons);
 		}
-		if (innerPred.getPred().getParList() != null) {
-			for (final SuPar var : innerPred.getPred().getParList().getParameters()) {
-				if (var.getVal() != null) {
-					final LiteralExpression lit = var.getVal();
-
-					final ObjectImpl object = (ObjectImpl) ((LiteralExpression) lit.getLit().getName()).getValue();
-					final String type = ((ObjectDecl) object.eContainer()).getObjectType().getQualifiedName();
-					final String variable = object.getName();
-
-					final String part = var.getVal().getPart();
-					if (part != null) {
-						variables.add(new CrySLObject(variable, type, new CrySLSplitter(Integer.parseInt(lit.getInd()), Utils.filterQuotes(lit.getSplit()))));
-					} else {
-						variables.add(new CrySLObject(variable, type));
-					}
-				} else {
-					variables.add(new CrySLObject(UNDERSCORE, NULL));
-				}
-			}
-		}
-		return new CrySLPredicate(null, innerPred.getPred().getPredName(), variables, (innerPred.getNot() != null ? true : false), conditional);
+		CrySLPredicate islc = (CrySLPredicate) getPredicate(innerPred.getPred());
+		return new CrySLPredicate(islc.getBaseObject(), islc.getPredName(), islc.getParameters(), islc.isNegated(), conditional);	
 	}
 
 	private ISLConstraint getPredicate(Pred pred) {


### PR DESCRIPTION
# Description
The built-in methods (alg, mode, padding, and so on) do not work in the REQUIRES section. For example, in the Cipher rule, we have generatedkey[key, alg(transformation)], but the alg does not function and it is interpreted as generatedkey[key, transformation].

# Fix
The previous parsing code was actually a dublicate of the getPredicate() method, but it had no check for the “consPred” field, in which ‘alg(’, ‘mode(’ and ‘pad(’ is defined. Hence I just reuse the correctly working getPredicate() method at this place.

More background:
As you can also see in the crysl gramma, "pred" field in non-terminal "PredLit"("innerPred.getPred()" in Java code) is defined as a normal predicate and hence it can be simply interpreted like any other predicate too.
https://github.com/CROSSINGTUD/CryptSL/blob/25dc97eebdfd30989c312d28dc79a50fb4cc1209/de.darmstadt.tu.crossing.CrySL/src/de/darmstadt/tu/crossing/CrySL.xtext#L245

Fixes #457 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] by @shahrzadav with several crysl files

**Test Configuration**:
* Eclipse Version:
* Java Version:
* OS:

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

