### PR TITLE
Fixed CogniCrypt build fails caused by tests

### DIFF
--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
@@ -17,7 +17,6 @@ import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.utils.DeveloperProject;
 
 public class CodeGenLocationSelectionTest {
-	String taskName = "Encryption";
 	
 	/**
 	 * Scenario: user doesn't select a specific class or package.
@@ -36,7 +35,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, generatedProject.getResource(),
-				codeGenerator, developerProject, taskName);
+				codeGenerator, developerProject);
 		
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -76,7 +75,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedPackage.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, generatedPackage.getResource(),
-				codeGenerator, developerProject, taskName);
+				codeGenerator, developerProject);
 
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -114,7 +113,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator,
-				developerProject, taskName);
+				developerProject);
 		
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/CodeGenLocationSelectionTest.java
@@ -12,11 +12,13 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.utils.DeveloperProject;
 
 public class CodeGenLocationSelectionTest {
+	
 	
 	/**
 	 * Scenario: user doesn't select a specific class or package.
@@ -25,7 +27,9 @@ public class CodeGenLocationSelectionTest {
 	 */
 	@Test
 	public void noSpecificSelection() throws Exception {
-		// task
+		//task
+		Task EncTask = TestUtils.getTask("Encryption");
+		// template
 		String template = "secretkeyencryption";
 		
 		// create Java project without any package or class
@@ -35,7 +39,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, generatedProject.getResource(),
-				codeGenerator, developerProject);
+				codeGenerator, developerProject, EncTask);
 		
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -62,6 +66,8 @@ public class CodeGenLocationSelectionTest {
 	@Test
 	public void packageSelection() throws Exception {
 		// task
+		Task EncTask = TestUtils.getTask("Encryption");
+		// template
 		String template = "secretkeyencryption";
 
 		// package name
@@ -75,7 +81,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedPackage.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, generatedPackage.getResource(),
-				codeGenerator, developerProject);
+				codeGenerator, developerProject, EncTask);
 
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -102,6 +108,8 @@ public class CodeGenLocationSelectionTest {
 	@Test
 	public void ownClassSelection() throws Exception {
 		// task
+		Task EncTask = TestUtils.getTask("Encryption");
+		// template
 		String template = "secretkeyencryption";
 
 		// create java project with a test class
@@ -113,7 +121,7 @@ public class CodeGenLocationSelectionTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator,
-				developerProject);
+				developerProject, EncTask);
 		
 		// run code generation
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/DigitalSignaturesCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/DigitalSignaturesCodeGenTest.java
@@ -25,12 +25,12 @@ public class DigitalSignaturesCodeGenTest {
 	@Test
 	public void testCodeGenerationDigSignatures() {
 		String template = "digitalsignatures";
-		String taskName = "DigitalSignatures";
+//		String taskName = "DigitalSignatures";
 		IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_DigSign");
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, taskName);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/DigitalSignaturesCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/DigitalSignaturesCodeGenTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.core.Constants;
@@ -25,12 +26,12 @@ public class DigitalSignaturesCodeGenTest {
 	@Test
 	public void testCodeGenerationDigSignatures() {
 		String template = "digitalsignatures";
-//		String taskName = "DigitalSignatures";
+		Task DigSigTask = TestUtils.getTask("DigitalSignatures");
 		IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_DigSign");
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, DigSigTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
@@ -29,7 +29,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -54,7 +54,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -81,7 +81,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -93,7 +93,7 @@ public class EncryptionCodeGenTest {
 		ICompilationUnit encClassUnit = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName, "SecureEncryptor.java");
 		TestUtils.openJavaFileInWorkspace(developerProject, Constants.PackageName, encClassUnit);
 		assertEquals(3, TestUtils.countMethods(encClassUnit));
-		assertEquals(12, TestUtils.countStatements(encClassUnit, "getKey"));
+		assertEquals(12, TestUtils.countStatements(encClassUnit, "generateKey"));
 		assertEquals(15, TestUtils.countStatements(encClassUnit, "encrypt"));
 		assertEquals(13, TestUtils.countStatements(encClassUnit, "decrypt"));
 		TestUtils.deleteProject(testJavaProject.getProject());
@@ -106,7 +106,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -133,7 +133,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -145,7 +145,7 @@ public class EncryptionCodeGenTest {
 		ICompilationUnit encClassUnit = TestUtils.getICompilationUnit(developerProject, Constants.PackageNameAsName, "SecureEncryptor.java");
 		TestUtils.openJavaFileInWorkspace(developerProject, Constants.PackageName, encClassUnit);
 		assertEquals(3, TestUtils.countMethods(encClassUnit));
-		assertEquals(12, TestUtils.countStatements(encClassUnit, "getKey"));
+		assertEquals(12, TestUtils.countStatements(encClassUnit, "generateKey"));
 		assertEquals(14, TestUtils.countStatements(encClassUnit, "encrypt"));
 		assertEquals(12, TestUtils.countStatements(encClassUnit, "decrypt"));
 		TestUtils.deleteProject(testJavaProject.getProject());
@@ -158,7 +158,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -185,7 +185,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, "Encryption");
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/EncryptionCodeGenTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.core.Constants;
@@ -21,7 +22,10 @@ import de.cognicrypt.utils.DeveloperProject;
  * @author Shahrzad Asghari
  */
 public class EncryptionCodeGenTest {
-
+	
+	//task
+	Task EncTask = TestUtils.getTask("Encryption");
+	
 	@Test
 	public void testCodeGenerationEncryption() {
 		String template = "encryption";
@@ -29,7 +33,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -54,7 +58,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -81,7 +85,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -106,7 +110,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -133,7 +137,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -158,7 +162,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);
@@ -185,7 +189,7 @@ public class EncryptionCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, EncTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/SecurePasswordCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/SecurePasswordCodeGenTest.java
@@ -25,12 +25,12 @@ public class SecurePasswordCodeGenTest {
 	@Test
 	public void testCodeGenerationSecurePassword() {
 		String template = "securepassword";
-		String taskName = "SecurePassword";
+//		String taskName = "SecurePassword";
 		IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_SecPwd");
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, taskName);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/SecurePasswordCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/SecurePasswordCodeGenTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.core.Constants;
@@ -25,12 +26,13 @@ public class SecurePasswordCodeGenTest {
 	@Test
 	public void testCodeGenerationSecurePassword() {
 		String template = "securepassword";
-//		String taskName = "SecurePassword";
+		Task SecPassTask = TestUtils.getTask("SecurePassword");
+
 		IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_SecPwd");
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, SecPassTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/StringHasherCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/StringHasherCodeGenTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.core.Constants;
@@ -21,12 +22,14 @@ public class StringHasherCodeGenTest {
 	
 	@Test
 	public void testCodeGenerationStringHashing() {
+		//there is no task for string hashing. pur securePassword for now
+		Task SecPassTask = TestUtils.getTask("SecurePassword");
 		String template = "stringhashing";
 		IJavaProject testJavaProject = TestUtils.createJavaProject("TestProject_StrHash");
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, SecPassTask);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/StringHasherCodeGenTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/StringHasherCodeGenTest.java
@@ -26,7 +26,7 @@ public class StringHasherCodeGenTest {
 		IResource targetFile = TestUtils.generateJavaClassInJavaProject(testJavaProject, CodeGenTestConstants.PACKAGE_NAME, CodeGenTestConstants.CLASS_NAME);
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(targetFile);
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
-		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject, null);
+		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(template, targetFile, codeGenerator, developerProject);
 
 		boolean encCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
 		assertTrue(encCheck);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/TwoTimesCogniCryptRunTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/TwoTimesCogniCryptRunTest.java
@@ -49,7 +49,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject, "Encryption");
+				generatedProject.getResource(), codeGenerator, developerProject);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -57,7 +57,7 @@ public class TwoTimesCogniCryptRunTest {
 
 		// setup for second generation
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, generatedProject.getResource(), codeGenerator,
-				developerProject, "SecurePassword");
+				developerProject);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -98,7 +98,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject, "Encryption");
+				generatedProject.getResource(), codeGenerator, developerProject);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -116,7 +116,7 @@ public class TwoTimesCogniCryptRunTest {
 		codeGenerator = new CrySLBasedCodeGenerator(outputClass.getResource());
 		developerProject = codeGenerator.getDeveloperProject();
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, outputClass.getResource(), codeGenerator,
-				developerProject, "SecurePassword");
+				developerProject);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -154,7 +154,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject, "Encryption");
+				generatedProject.getResource(), codeGenerator, developerProject);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -172,7 +172,7 @@ public class TwoTimesCogniCryptRunTest {
 		codeGenerator = new CrySLBasedCodeGenerator(encClass.getResource());
 		developerProject = codeGenerator.getDeveloperProject();
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, encClass.getResource(), codeGenerator,
-				developerProject, "SecurePassword");
+				developerProject);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/TwoTimesCogniCryptRunTest.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/generator/test/TwoTimesCogniCryptRunTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import de.cognicrypt.codegenerator.generator.CodeGenerator;
 import de.cognicrypt.codegenerator.generator.CrySLBasedCodeGenerator;
+import de.cognicrypt.codegenerator.tasks.Task;
 import de.cognicrypt.codegenerator.testutilities.TestUtils;
 import de.cognicrypt.codegenerator.wizard.CrySLConfiguration;
 import de.cognicrypt.core.Constants;
@@ -38,6 +39,9 @@ public class TwoTimesCogniCryptRunTest {
 	 */
 	@Test
 	public void runCCTwoTimesNoSpecificSelection() throws Exception {
+		// task
+		Task EncTask = TestUtils.getTask("Encryption");
+		Task SecPassTask = TestUtils.getTask("SecurePassword");
 		// task template
 		String templateSecEnc = "secretkeyencryption";
 		String templateSecPwd = "securepassword";
@@ -49,7 +53,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject);
+				generatedProject.getResource(), codeGenerator, developerProject, EncTask);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -57,7 +61,7 @@ public class TwoTimesCogniCryptRunTest {
 
 		// setup for second generation
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, generatedProject.getResource(), codeGenerator,
-				developerProject);
+				developerProject, SecPassTask);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -87,7 +91,10 @@ public class TwoTimesCogniCryptRunTest {
 	 */
 	@Test
 	public void runCCTwoTimesOutputClassSelection() throws Exception {
-		// task template
+		// task
+		Task EncTask = TestUtils.getTask("Encryption");
+		Task SecPassTask = TestUtils.getTask("SecurePassword");
+		// task
 		String templateSecEnc = "secretkeyencryption";
 		String templateSecPwd = "securepassword";
 
@@ -98,7 +105,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject);
+				generatedProject.getResource(), codeGenerator, developerProject, EncTask);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -116,7 +123,7 @@ public class TwoTimesCogniCryptRunTest {
 		codeGenerator = new CrySLBasedCodeGenerator(outputClass.getResource());
 		developerProject = codeGenerator.getDeveloperProject();
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, outputClass.getResource(), codeGenerator,
-				developerProject);
+				developerProject, SecPassTask);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -143,6 +150,9 @@ public class TwoTimesCogniCryptRunTest {
 	 */
 	@Test
 	public void runCCTwoTimesLogicClassSelection() throws Exception {
+		// task
+		Task EncTask = TestUtils.getTask("Encryption");
+		Task SecPassTask = TestUtils.getTask("SecurePassword");
 		// task template
 		String templateSecEnc = "secretkeyencryption";
 		String templateSecPwd = "securepassword";
@@ -154,7 +164,7 @@ public class TwoTimesCogniCryptRunTest {
 		CodeGenerator codeGenerator = new CrySLBasedCodeGenerator(generatedProject.getResource());
 		DeveloperProject developerProject = codeGenerator.getDeveloperProject();
 		CrySLConfiguration chosenConfig = TestUtils.createCrySLConfiguration(templateSecEnc,
-				generatedProject.getResource(), codeGenerator, developerProject);
+				generatedProject.getResource(), codeGenerator, developerProject, EncTask);
 
 		// first generation run
 		boolean secEncCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");
@@ -172,7 +182,7 @@ public class TwoTimesCogniCryptRunTest {
 		codeGenerator = new CrySLBasedCodeGenerator(encClass.getResource());
 		developerProject = codeGenerator.getDeveloperProject();
 		chosenConfig = TestUtils.createCrySLConfiguration(templateSecPwd, encClass.getResource(), codeGenerator,
-				developerProject);
+				developerProject, SecPassTask);
 
 		// second generation run
 		boolean secPwdCheck = codeGenerator.generateCodeTemplates(chosenConfig, "");

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/testutilities/TestUtils.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/testutilities/TestUtils.java
@@ -259,7 +259,7 @@ public class TestUtils {
 	 * @param developerProject The project
 	 * @return The configuration for a given task
 	 */
-	public static CrySLConfiguration createCrySLConfiguration(String template, IResource targetFile, CodeGenerator codeGenerator, DeveloperProject developerProject) {
+	public static CrySLConfiguration createCrySLConfiguration(String template, IResource targetFile, CodeGenerator codeGenerator, DeveloperProject developerProject, final Task t) {
 		CrySLConfiguration chosenConfig = null;
 		try {
 			File templateFile = CodeGenUtils.getResourceFromWithin(Constants.codeTemplateFolder + template).listFiles()[0];
@@ -271,9 +271,11 @@ public class TestUtils {
 			Files.createDirectories(Paths.get(targetFile.getProject().getLocation().toOSString() + projectRelDir));
 			Files.copy(templateFile.toPath(), Paths.get(resFileOSPath), StandardCopyOption.REPLACE_EXISTING);
 			developerProject.refresh();
-
+			
+			final HashMap<Question, Answer> constraints = TestUtils.setDefaultConstraintsForTask(t);
+			
 			GeneratorClass genClass = ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile);
-			chosenConfig = new CrySLConfiguration("", genClass);
+			chosenConfig = new CrySLConfiguration("", genClass, constraints, t.getName(), developerProject);
 			return chosenConfig;
 		} catch(CoreException | IOException e) {
 			Activator.getDefault().logError(e);

--- a/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/testutilities/TestUtils.java
+++ b/plugins/de.cognicrypt.codegenerator.tests/src/de/cognicrypt/codegenerator/testutilities/TestUtils.java
@@ -246,7 +246,7 @@ public class TestUtils {
 		final HashMap<Question, Answer> constraints = TestUtils.setDefaultConstraintsForTask(t);
 		final List<InstanceClafer> instList = instGen.generateInstances(constraints);
 		final InstanceClafer inst = instList.get(0);
-		final Configuration ret = new XSLConfiguration(inst, constraints, developerProject.getProjectPath() + Constants.innerFileSeparator + Constants.pathToClaferInstanceFile, t.getName());
+		final Configuration ret = new XSLConfiguration(inst, constraints, developerProject.getProjectPath() + Constants.innerFileSeparator + Constants.pathToClaferInstanceFile, t.getName(), developerProject);
 		return ret;
 	}
 
@@ -259,7 +259,7 @@ public class TestUtils {
 	 * @param developerProject The project
 	 * @return The configuration for a given task
 	 */
-	public static CrySLConfiguration createCrySLConfiguration(String template, IResource targetFile, CodeGenerator codeGenerator, DeveloperProject developerProject, String selectedTask) {
+	public static CrySLConfiguration createCrySLConfiguration(String template, IResource targetFile, CodeGenerator codeGenerator, DeveloperProject developerProject) {
 		CrySLConfiguration chosenConfig = null;
 		try {
 			File templateFile = CodeGenUtils.getResourceFromWithin(Constants.codeTemplateFolder + template).listFiles()[0];
@@ -273,7 +273,7 @@ public class TestUtils {
 			developerProject.refresh();
 
 			GeneratorClass genClass = ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile);
-			chosenConfig = new CrySLConfiguration("", genClass, selectedTask);
+			chosenConfig = new CrySLConfiguration("", genClass);
 			return chosenConfig;
 		} catch(CoreException | IOException e) {
 			Activator.getDefault().logError(e);

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionfiles/SecureEncryptor.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/encryptionfiles/SecureEncryptor.java
@@ -35,7 +35,7 @@ public class SecureEncryptor {
 	 * @throws InvalidKeySpecException This exception is thrown when key specifications are invalid.
 	 */
 	
-	public javax.crypto.SecretKey getenerateKey(char[] pwd) {
+	public javax.crypto.SecretKey generateKey(char[] pwd) {
 		byte[] salt = new byte[32];
 		javax.crypto.SecretKey encryptionKey = null;
 		int keysize = 128;

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/stringhashing/StringHasher.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/crysl/templates/stringhashing/StringHasher.java
@@ -16,6 +16,9 @@ import java.util.Base64;
 
 import de.cognicrypt.codegenerator.crysl.CrySLCodeGenerator;
 
+/**
+ * The Class StringHasher hashes a given String and verifies the hash.
+ */
 public class StringHasher {
 
 	public static java.lang.String createHash(java.lang.String msg) throws GeneralSecurityException {

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/generator/CodeGenerator.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/generator/CodeGenerator.java
@@ -171,8 +171,15 @@ public abstract class CodeGenerator {
 				}
 			}
 		}
-
-		final int imports = docContent.startsWith("package") ? docContent.indexOf("\n") : 0;
+		int imports = 0;
+		//if the file starts with package then the imports should be on the line after that
+		if (docContent.startsWith("package")) {
+			imports = docContent.indexOf("\n");
+		
+		}if(docContent.startsWith("/*") && docContent.contains("package")) { //if the file starts with the header comment, then the imports should be added after header and package name
+			int temp = docContent.indexOf("package");
+			imports = docContent.indexOf("\n", temp);
+		}
 		final String[] callsForGenClasses = getCallsForGenClasses(temporaryOutputFile);
 		currentlyOpenDocument.replace(cursorPos, 0, callsForGenClasses[1]);
 		currentlyOpenDocument.replace(imports, 0, callsForGenClasses[0] + Constants.lineSeparator);

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/generator/CrySLBasedCodeGenerator.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/generator/CrySLBasedCodeGenerator.java
@@ -1255,6 +1255,7 @@ public class CrySLBasedCodeGenerator extends CodeGenerator {
 	    matcher.find();
 	    String header =  matcher.group();
 	    //retrieve javaDoc
+//	    List cl = cu.getCommentList();
 		String classJavaDoc = (String) cu.getCommentList().get(1).toString();
 		
 		GeneratorClass templateClass = new GeneratorClass();

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
@@ -268,7 +268,7 @@ public class AltConfigWizard extends Wizard {
 					codeGenerator.getDeveloperProject().refresh();
 
 					resetAnswers();
-					chosenConfig = new CrySLConfiguration(resFileOSPath, ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile), selectedTask.getName());
+					chosenConfig = new CrySLConfiguration(resFileOSPath, ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile));
 					break;
 				case XSL:
 					this.constraints = (this.constraints != null) ? this.constraints : new HashMap<>();
@@ -279,7 +279,7 @@ public class AltConfigWizard extends Wizard {
 					// Initialize Code Generation
 					codeGenerator = new XSLBasedGenerator(targetFile, codeTemplate);
 					chosenConfig = new XSLConfiguration(instanceGenerator.getInstances().values().iterator()
-						.next(), this.constraints, codeGenerator.getDeveloperProject().getProjectPath() + Constants.innerFileSeparator + Constants.pathToClaferInstanceFile, selectedTask.getName());
+						.next(), this.constraints, codeGenerator.getDeveloperProject().getProjectPath() + Constants.innerFileSeparator + Constants.pathToClaferInstanceFile, selectedTask.getName(), codeGenerator.getDeveloperProject());
 					break;
 				default:
 					return false;

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
@@ -268,7 +268,7 @@ public class AltConfigWizard extends Wizard {
 					codeGenerator.getDeveloperProject().refresh();
 
 					resetAnswers();
-					chosenConfig = new CrySLConfiguration(resFileOSPath, ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile));
+					chosenConfig = new CrySLConfiguration(resFileOSPath, ((CrySLBasedCodeGenerator) codeGenerator).setUpTemplateClass(pathToTemplateFile, templateFile), this.constraints, selectedTask.getName(), codeGenerator.getDeveloperProject());
 					break;
 				case XSL:
 					this.constraints = (this.constraints != null) ? this.constraints : new HashMap<>();

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/Configuration.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/Configuration.java
@@ -1,7 +1,6 @@
 /********************************************************************************
  * Copyright (c) 2015-2019 TU Darmstadt, Paderborn University
  * 
-
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -19,11 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.dom4j.io.XMLWriter;
+import org.eclipse.core.runtime.CoreException;
 
 import de.cognicrypt.codegenerator.Activator;
 import de.cognicrypt.codegenerator.question.Answer;
 import de.cognicrypt.codegenerator.question.Question;
 import de.cognicrypt.core.Constants;
+import de.cognicrypt.utils.DeveloperProject;
 import de.cognicrypt.utils.FileUtils;
 import de.cognicrypt.utils.Utils;
 
@@ -38,22 +39,26 @@ public abstract class Configuration {
 
 	final protected Map<Question, Answer> options;
 	final protected String pathOnDisk;
-	protected Answer answr;
-	final protected String taskName;
+	protected String taskName;
+	protected DeveloperProject developerProject;
 
 	@SuppressWarnings("unchecked")
-	public Configuration(Map<?, ?> constraints, String pathOnDisk, String taskName) {
-		this.answr = new Answer();
+	public Configuration(Map<?, ?> constraints, String pathOnDisk, String taskName, DeveloperProject developerProject) {
+//		this.developerProject = null;
 		this.pathOnDisk = pathOnDisk;
 		this.options = (Map<Question, Answer>) constraints;
+		this.developerProject = developerProject;
+		String path = "";
+		path = developerProject.getProjectPath();
 		
 		this.taskName = taskName;
-
+		
 		JSONObject obj = new JSONObject();
+		
 		this.options.forEach((question,answer) ->obj.put(question.getQuestionText(), answer.getValue()));
-		String jsonPath = Utils.getCurrentProject().getLocation().toOSString() + Constants.innerFileSeparator + taskName + Constants.JSON_EXTENSION;
+		//String jsonPath = Utils.getCurrentProject().getLocation().toOSString() + Constants.innerFileSeparator + taskName + Constants.JSON_EXTENSION;
 
-		File file = new File(jsonPath);  
+		File file = new File(path + Constants.innerFileSeparator + taskName + Constants.JSON_EXTENSION);  
         try {
 			file.createNewFile();
 	        FileWriter fileWriter = new FileWriter(file);
@@ -63,6 +68,17 @@ public abstract class Configuration {
 		} catch (IOException e) {
 			Activator.getDefault().logError(e);
 		}  
+		
+	}
+	
+	@SuppressWarnings("unchecked")
+	public Configuration(Map<?, ?> constraints, String pathOnDisk) {
+		this.pathOnDisk = pathOnDisk;
+		this.options = (Map<Question, Answer>) constraints;
+		
+		JSONObject obj = new JSONObject();
+		
+		this.options.forEach((question,answer) ->obj.put(question.getQuestionText(), answer.getValue()));
 	}
 
 	/**

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/Configuration.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/Configuration.java
@@ -39,25 +39,24 @@ public abstract class Configuration {
 
 	final protected Map<Question, Answer> options;
 	final protected String pathOnDisk;
-	protected String taskName;
+	protected String taskName;	// this is to make the JSON file of question and answers
 	protected DeveloperProject developerProject;
 
 	@SuppressWarnings("unchecked")
 	public Configuration(Map<?, ?> constraints, String pathOnDisk, String taskName, DeveloperProject developerProject) {
-//		this.developerProject = null;
+
 		this.pathOnDisk = pathOnDisk;
 		this.options = (Map<Question, Answer>) constraints;
 		this.developerProject = developerProject;
+		this.taskName = taskName;
+		
 		String path = "";
 		path = developerProject.getProjectPath();
-		
-		this.taskName = taskName;
 		
 		JSONObject obj = new JSONObject();
 		
 		this.options.forEach((question,answer) ->obj.put(question.getQuestionText(), answer.getValue()));
-		//String jsonPath = Utils.getCurrentProject().getLocation().toOSString() + Constants.innerFileSeparator + taskName + Constants.JSON_EXTENSION;
-
+		// this file contains the question and answers of the task user chose and picked in codegen wizard
 		File file = new File(path + Constants.innerFileSeparator + taskName + Constants.JSON_EXTENSION);  
         try {
 			file.createNewFile();
@@ -69,16 +68,6 @@ public abstract class Configuration {
 			Activator.getDefault().logError(e);
 		}  
 		
-	}
-	
-	@SuppressWarnings("unchecked")
-	public Configuration(Map<?, ?> constraints, String pathOnDisk) {
-		this.pathOnDisk = pathOnDisk;
-		this.options = (Map<Question, Answer>) constraints;
-		
-		JSONObject obj = new JSONObject();
-		
-		this.options.forEach((question,answer) ->obj.put(question.getQuestionText(), answer.getValue()));
 	}
 
 	/**

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CrySLConfiguration.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CrySLConfiguration.java
@@ -14,16 +14,19 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import de.cognicrypt.codegenerator.generator.GeneratorClass;
+import de.cognicrypt.codegenerator.question.Answer;
+import de.cognicrypt.codegenerator.question.Question;
 import de.cognicrypt.utils.DeveloperProject;
 
 public class CrySLConfiguration extends Configuration {
 
 	private final GeneratorClass template;
 
-	public CrySLConfiguration(String pathOnDisk, GeneratorClass templateClass) throws IOException {
-		super(new HashMap<>(), pathOnDisk);
+	public CrySLConfiguration(String pathOnDisk, GeneratorClass templateClass, Map<Question, Answer> constraints, String taskName, DeveloperProject developerProject) throws IOException {
+		super(constraints, pathOnDisk, taskName, developerProject);
 		this.template = templateClass;
 	}
 

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CrySLConfiguration.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/CrySLConfiguration.java
@@ -16,13 +16,14 @@ import java.util.HashMap;
 import java.util.List;
 
 import de.cognicrypt.codegenerator.generator.GeneratorClass;
+import de.cognicrypt.utils.DeveloperProject;
 
 public class CrySLConfiguration extends Configuration {
 
 	private final GeneratorClass template;
 
-	public CrySLConfiguration(String pathOnDisk, GeneratorClass templateClass, String selectedTask) throws IOException {
-		super(new HashMap<>(), pathOnDisk, selectedTask);
+	public CrySLConfiguration(String pathOnDisk, GeneratorClass templateClass) throws IOException {
+		super(new HashMap<>(), pathOnDisk);
 		this.template = templateClass;
 	}
 

--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/XSLConfiguration.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/XSLConfiguration.java
@@ -28,13 +28,14 @@ import de.cognicrypt.codegenerator.question.Answer;
 import de.cognicrypt.codegenerator.question.Question;
 import de.cognicrypt.codegenerator.utilities.XMLClaferParser;
 import de.cognicrypt.core.Constants;
+import de.cognicrypt.utils.DeveloperProject;
 
 public class XSLConfiguration extends Configuration {
 
 	final private InstanceClafer instance;
 
-	public XSLConfiguration(InstanceClafer instance, Map<Question, Answer> constraints, String pathOnDisk, String taskName) throws IOException {
-		super(constraints, pathOnDisk, taskName);
+	public XSLConfiguration(InstanceClafer instance, Map<Question, Answer> constraints, String pathOnDisk, String taskName, DeveloperProject developerProject) throws IOException {
+		super(constraints, pathOnDisk, taskName, developerProject);
 		this.instance = instance;
 	}
 

--- a/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/Ruleset.java
+++ b/plugins/de.cognicrypt.staticanalyzer/src/de/cognicrypt/staticanalyzer/utilities/Ruleset.java
@@ -38,12 +38,12 @@ public class Ruleset {
 	}
 
 	public Ruleset(String url) {
-		this.folderName = url.substring(url.lastIndexOf(File.separator) + 1);
+		this.folderName = url.substring(url.lastIndexOf('/') + 1);
 		this.urlOrPath = url;
 	}
 
 	public Ruleset(String url, boolean checked) {
-		this.folderName = url.substring(url.lastIndexOf(File.separator) + 1);
+		this.folderName = url.substring(url.lastIndexOf('/') + 1);
 		this.urlOrPath = url;
 		this.isChecked = checked;
 	}


### PR DESCRIPTION
# Description

The tests were failing because for some tasks CogniCrypt was not able to create the JSON file related to the "suppress legacy client errors" issue.  Also, all templates needed to have JavaDoc which StringHasher did not since there is no task connected to this template, but there is a test for it. Further, now there will be a JSON file (with questions and answers) created after a user generated a code with codeGen for all XSL-based and CrySL-based tasks.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Eclipse Version: 2020-06
* Java Version: 1.8
* OS: Windows 10

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

