### PR TITLE
Add skipBuildInfo flag to prevent null value

### DIFF
--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -59,6 +59,7 @@
 							<goal>generate-repository-facade</goal>
 						</goals>
 						<configuration>
+							<skipBuildInfo>true</skipBuildInfo>
 							<associateSites>
 								<associateSite>http://download.eclipse.org/cognicrypt/stable</associateSite>
 								<associateSite>http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/</associateSite>


### PR DESCRIPTION
# Description

The skipBuildInfo flag skips the buildinfo.json file generation. The generation currently leads to an error which prevents the CI from running. However, the buildinfo.json is not used and skipping the generation should not result in any other error. The flag is temporarily added to circumvent the CI from failing (#473).

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Eclipse Version:
* Java Version:
* OS:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

