### PR TITLE
Fixed inconsistency with the code template name generation

### DIFF
--- a/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
+++ b/plugins/de.cognicrypt.codegenerator/src/main/java/de/cognicrypt/codegenerator/wizard/AltConfigWizard.java
@@ -14,8 +14,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.swing.JDialog;
@@ -124,8 +128,13 @@ public class AltConfigWizard extends Wizard {
 		//Only case that is left: BeginnerTaskQuestionPage
 		final BeginnerTaskQuestionPage curQuestionPage = (BeginnerTaskQuestionPage) currentPage;
 		final HashMap<Question, Answer> curQuestionAnswerMap = curQuestionPage.getMap();
+		
+		List<Map.Entry<Question, Answer>> curQuestionAnswerList = new LinkedList<Map.Entry<Question, Answer>>(curQuestionAnswerMap.entrySet());
+		Collections.sort(
+			curQuestionAnswerList,
+            (i1, i2) -> Integer.compare(i1.getKey().getId(), i2.getKey().getId()));
 
-		for (final Entry<Question, Answer> entry : curQuestionAnswerMap.entrySet()) {
+		for (final Map.Entry<Question, Answer> entry : curQuestionAnswerList) {
 			this.constraints.put(entry.getKey(), entry.getValue());
 		}
 


### PR DESCRIPTION
# Description

Seperate pull request to address issue #398. In this PR only the commit from #441  is added that fixes this issue.

"Corrected inconsistency with the code template name generation when the order of option selected by the user varies."

Fixes #398 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


